### PR TITLE
Introduce and use a micro size server instancetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ VirtualMachineClusterInstancetype
 server.medium
 ---
 VirtualMachineClusterInstancetype
+server.micro
+---
+VirtualMachineClusterInstancetype
 server.small
 ---
 VirtualMachineClusterInstancetype
@@ -182,6 +185,9 @@ server.large
 ---
 VirtualMachineInstancetype
 server.medium
+---
+VirtualMachineInstancetype
+server.micro
 ---
 VirtualMachineInstancetype
 server.small

--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -72,6 +72,18 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    kubevirt.io/size: mirco
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
     kubevirt.io/size: small
   name: server.small
 spec:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -72,6 +72,18 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterInstancetype
 metadata:
   labels:
+    kubevirt.io/size: mirco
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineClusterInstancetype
+metadata:
+  labels:
     kubevirt.io/size: small
   name: server.small
 spec:
@@ -824,6 +836,18 @@ spec:
     guest: 1
   memory:
     guest: 4Gi
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineInstancetype
+metadata:
+  labels:
+    kubevirt.io/size: mirco
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
 ---
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineInstancetype

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -72,6 +72,18 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineInstancetype
 metadata:
   labels:
+    kubevirt.io/size: mirco
+  name: server.micro
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi
+---
+apiVersion: instancetype.kubevirt.io/v1alpha2
+kind: VirtualMachineInstancetype
+metadata:
+  labels:
     kubevirt.io/size: small
   name: server.small
 spec:

--- a/common-instancetypes/instancetypes/server/micro/kustomization.yaml
+++ b/common-instancetypes/instancetypes/server/micro/kustomization.yaml
@@ -3,8 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ./large
-  - ./medium
-  - ./small
-  - ./tiny
-  - ./micro
+  - ../base
+
+components:
+  - ../../sizes/micro

--- a/common-instancetypes/instancetypes/sizes/micro/kustomization.yaml
+++ b/common-instancetypes/instancetypes/sizes/micro/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+nameSuffix: .micro
+
+patches:
+  - path: micro.yaml
+    target:
+      kind: VirtualMachineInstancetype
+  - path: micro.yaml
+    target:
+      kind: VirtualMachineClusterInstancetype

--- a/common-instancetypes/instancetypes/sizes/micro/micro.yaml
+++ b/common-instancetypes/instancetypes/sizes/micro/micro.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachineInstancetype
+metadata:
+  name: VirtualMachineInstancetype
+  labels:
+    kubevirt.io/size: mirco
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: 256Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

This should be suitable for use with CirrOS [1] and other minimal test
OSes used by KubeVirt CI.

[1] https://github.com/cirros-dev/cirros/issues/53

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new `micro` size has been introduced and used by the existing `server` family of instance types.
```
