### PR TITLE
check: Add pwd as safe git directory

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -30,6 +30,3 @@ RUN go install github.com/yannh/kubeconform/cmd/kubeconform@v0.5.0 && mv /root/g
 # Download latest yq binary
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.29.2/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
-
-# We need to create a directory for the code and add it as a safe.directory before use, allowing git commands to work correctly.
-RUN mkdir /common-instancetypes && git config --global --add safe.directory /common-instancetypes

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# We need to add the current directory as a safe git directory before running any commands
+git config --global --add safe.directory "$(pwd)"
+
 git diff --quiet common*.yaml README.md
 uncommited=$?
 if [[ $uncommited -eq 1 ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

We need the current working directory to be marked as safe within the git config before running `git diff`.

This is required when running the script within a container image or prow job otherwise the following error is shown:

```
$ COMMON_INSTANCETYPES_CRI=docker make check
./scripts/cri.sh  "./scripts/check.sh"
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
```

A previous attempt to fix this in the Dockerfile is removed as the assumed path of the repo changes between local docker runs and prow jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
