### PR TITLE
cri: Use private unshared label for bind mount

### DIFF
--- a/scripts/cri.sh
+++ b/scripts/cri.sh
@@ -5,4 +5,4 @@ if [ "${COMMON_INSTANCETYPES_CRI}" == "" ]; then
     exit $?
 fi
 
-${COMMON_INSTANCETYPES_CRI} run -v "$(pwd):/common-instancetypes" -e KUBEVIRT_VERSION=${KUBEVIRT_VERSION} --rm ${COMMON_INSTANCETYPES_IMAGE} /usr/bin/bash -c "cd /common-instancetypes &&  $@"
+${COMMON_INSTANCETYPES_CRI} run -v "$(pwd):/common-instancetypes:rw,Z" -e KUBEVIRT_VERSION=${KUBEVIRT_VERSION} --rm ${COMMON_INSTANCETYPES_IMAGE} /usr/bin/bash -c "cd /common-instancetypes &&  $@"


### PR DESCRIPTION
Required by podman, otherwise we cannot run scripts within the mount.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
