### PR TITLE
Introduce OpenShift metadata to generated resources

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -152,9 +152,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-cirros
+    openshift.io/display-name: Cirros
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,cirros
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -2,6 +2,10 @@
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
@@ -13,6 +17,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -24,6 +32,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -38,6 +50,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -49,6 +65,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -63,6 +83,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -81,6 +105,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
@@ -102,6 +130,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
@@ -113,6 +145,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
@@ -131,6 +167,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -142,6 +182,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -156,6 +200,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -167,6 +215,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -181,6 +233,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -199,6 +255,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
@@ -220,6 +280,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
@@ -232,6 +296,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -275,6 +343,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -320,6 +392,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -368,6 +444,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -418,6 +498,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -461,6 +545,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -506,6 +594,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -549,6 +641,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -594,6 +690,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -637,6 +737,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -682,6 +786,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -730,6 +838,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -10,6 +10,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,alpine
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
 spec:
@@ -28,6 +29,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
 spec:
@@ -46,6 +48,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
 spec:
@@ -67,6 +70,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
 spec:
@@ -85,6 +89,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
 spec:
@@ -106,6 +111,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
 spec:
@@ -131,6 +137,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
 spec:
@@ -159,6 +166,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,cirros
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
 spec:
@@ -177,6 +185,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,fedora
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
 spec:
@@ -202,6 +211,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
 spec:
@@ -220,6 +230,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
 spec:
@@ -241,6 +252,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
 spec:
@@ -259,6 +271,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
 spec:
@@ -280,6 +293,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
 spec:
@@ -305,6 +319,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
 spec:
@@ -333,6 +348,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,ubuntu
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
 spec:
@@ -352,6 +368,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
 spec:
@@ -402,6 +419,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
 spec:
@@ -454,6 +472,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
 spec:
@@ -509,6 +528,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
 spec:
@@ -566,6 +586,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
 spec:
@@ -616,6 +637,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
 spec:
@@ -668,6 +690,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
 spec:
@@ -718,6 +741,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
 spec:
@@ -770,6 +794,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
 spec:
@@ -820,6 +845,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
 spec:
@@ -872,6 +898,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
 spec:
@@ -927,6 +954,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
 spec:

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -396,7 +396,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 10
+    openshift.io/display-name: Microsoft Windows 10 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -610,7 +610,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2012
+    openshift.io/display-name: Microsoft Windows Server 2012 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -712,7 +712,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2016
+    openshift.io/display-name: Microsoft Windows Server 2016 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -921,7 +921,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2022
+    openshift.io/display-name: Microsoft Windows Server 2022 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -3,9 +3,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-alpine
+    openshift.io/display-name: Alpine
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,alpine
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -186,9 +186,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -201,9 +204,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -219,9 +225,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -234,9 +243,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -252,9 +264,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -274,9 +289,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -164,9 +164,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-fedora
+    openshift.io/display-name: Fedora
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,fedora
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -320,9 +320,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-ubuntu
+    openshift.io/display-name: Ubuntu
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,ubuntu
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -18,9 +18,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -33,9 +36,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -51,9 +57,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -66,9 +75,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -84,9 +96,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -106,9 +121,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -333,9 +333,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -380,9 +383,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -429,9 +435,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -481,9 +490,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -535,9 +547,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -582,9 +597,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -631,9 +649,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -678,9 +699,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -727,9 +751,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -774,9 +801,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -823,9 +853,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -875,9 +908,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -669,6 +669,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
@@ -680,6 +684,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -691,6 +699,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -705,6 +717,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -716,6 +732,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -730,6 +750,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -748,6 +772,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
@@ -769,6 +797,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
@@ -780,6 +812,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
@@ -798,6 +834,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -809,6 +849,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -823,6 +867,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -834,6 +882,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -848,6 +900,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -866,6 +922,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
@@ -887,6 +947,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
@@ -899,6 +963,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -942,6 +1010,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -987,6 +1059,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -1035,6 +1111,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -1085,6 +1165,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -1128,6 +1212,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -1173,6 +1261,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -1216,6 +1308,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -1261,6 +1357,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -1304,6 +1404,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -1349,6 +1453,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -1397,6 +1505,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
@@ -2114,6 +2226,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
@@ -2125,6 +2241,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -2136,6 +2256,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -2150,6 +2274,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -2161,6 +2289,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -2175,6 +2307,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -2193,6 +2329,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
@@ -2214,6 +2354,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
@@ -2225,6 +2369,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
@@ -2243,6 +2391,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -2254,6 +2406,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -2268,6 +2424,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -2279,6 +2439,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -2293,6 +2457,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -2311,6 +2479,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
@@ -2332,6 +2504,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
@@ -2344,6 +2520,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -2387,6 +2567,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -2432,6 +2616,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -2480,6 +2668,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -2530,6 +2722,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -2573,6 +2769,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -2618,6 +2818,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -2661,6 +2865,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -2706,6 +2914,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -2749,6 +2961,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -2794,6 +3010,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -2842,6 +3062,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -677,6 +677,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,alpine
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
 spec:
@@ -695,6 +696,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
 spec:
@@ -713,6 +715,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
 spec:
@@ -734,6 +737,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
 spec:
@@ -752,6 +756,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
 spec:
@@ -773,6 +778,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
 spec:
@@ -798,6 +804,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
 spec:
@@ -826,6 +833,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,cirros
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
 spec:
@@ -844,6 +852,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,fedora
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
 spec:
@@ -869,6 +878,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
 spec:
@@ -887,6 +897,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
 spec:
@@ -908,6 +919,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
 spec:
@@ -926,6 +938,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
 spec:
@@ -947,6 +960,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
 spec:
@@ -972,6 +986,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
 spec:
@@ -1000,6 +1015,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,ubuntu
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
 spec:
@@ -1019,6 +1035,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
 spec:
@@ -1069,6 +1086,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
 spec:
@@ -1121,6 +1139,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
 spec:
@@ -1176,6 +1195,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
 spec:
@@ -1233,6 +1253,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
 spec:
@@ -1283,6 +1304,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
 spec:
@@ -1335,6 +1357,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
 spec:
@@ -1385,6 +1408,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
 spec:
@@ -1437,6 +1461,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
 spec:
@@ -1487,6 +1512,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
 spec:
@@ -1539,6 +1565,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
 spec:
@@ -1594,6 +1621,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
 spec:
@@ -2318,6 +2346,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,alpine
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
 spec:
@@ -2336,6 +2365,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
 spec:
@@ -2354,6 +2384,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
 spec:
@@ -2375,6 +2406,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
 spec:
@@ -2393,6 +2425,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
 spec:
@@ -2414,6 +2447,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
 spec:
@@ -2439,6 +2473,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
 spec:
@@ -2467,6 +2502,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,cirros
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
 spec:
@@ -2485,6 +2521,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,fedora
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
 spec:
@@ -2510,6 +2547,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
 spec:
@@ -2528,6 +2566,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
 spec:
@@ -2549,6 +2588,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
 spec:
@@ -2567,6 +2607,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
 spec:
@@ -2588,6 +2629,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
 spec:
@@ -2613,6 +2655,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
 spec:
@@ -2641,6 +2684,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,ubuntu
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
 spec:
@@ -2660,6 +2704,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
 spec:
@@ -2710,6 +2755,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
 spec:
@@ -2762,6 +2808,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
 spec:
@@ -2817,6 +2864,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
 spec:
@@ -2874,6 +2922,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
 spec:
@@ -2924,6 +2973,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
 spec:
@@ -2976,6 +3026,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
 spec:
@@ -3026,6 +3077,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
 spec:
@@ -3078,6 +3130,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
 spec:
@@ -3128,6 +3181,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
 spec:
@@ -3180,6 +3234,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
 spec:
@@ -3235,6 +3290,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
 spec:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1063,7 +1063,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 10
+    openshift.io/display-name: Microsoft Windows 10 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1277,7 +1277,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2012
+    openshift.io/display-name: Microsoft Windows Server 2012 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1379,7 +1379,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2016
+    openshift.io/display-name: Microsoft Windows Server 2016 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1588,7 +1588,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2022
+    openshift.io/display-name: Microsoft Windows Server 2022 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -2704,7 +2704,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 10
+    openshift.io/display-name: Microsoft Windows 10 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -2918,7 +2918,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2012
+    openshift.io/display-name: Microsoft Windows Server 2012 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -3020,7 +3020,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2016
+    openshift.io/display-name: Microsoft Windows Server 2016 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -3229,7 +3229,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2022
+    openshift.io/display-name: Microsoft Windows Server 2022 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -831,9 +831,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-fedora
+    openshift.io/display-name: Fedora
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,fedora
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
@@ -2460,9 +2463,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-fedora
+    openshift.io/display-name: Fedora
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,fedora
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -819,9 +819,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-cirros
+    openshift.io/display-name: Cirros
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,cirros
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
@@ -2457,9 +2460,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-cirros
+    openshift.io/display-name: Cirros
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,cirros
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -987,9 +987,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-ubuntu
+    openshift.io/display-name: Ubuntu
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,ubuntu
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
@@ -2619,9 +2622,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-ubuntu
+    openshift.io/display-name: Ubuntu
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,ubuntu
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -685,9 +685,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -700,9 +703,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -718,9 +724,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -733,9 +742,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -751,9 +763,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -773,9 +788,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
@@ -2242,9 +2260,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -2257,9 +2278,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -2275,9 +2299,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -2290,9 +2317,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -2308,9 +2338,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -2330,9 +2363,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -670,9 +670,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-alpine
+    openshift.io/display-name: Alpine
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,alpine
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
@@ -2305,9 +2308,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-alpine
+    openshift.io/display-name: Alpine
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,alpine
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1000,9 +1000,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -1047,9 +1050,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -1096,9 +1102,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -1148,9 +1157,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -1202,9 +1214,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -1249,9 +1264,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -1298,9 +1316,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -1345,9 +1366,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -1394,9 +1418,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -1441,9 +1468,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -1490,9 +1520,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -1542,9 +1575,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
@@ -2593,9 +2629,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -2640,9 +2679,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -2689,9 +2731,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -2741,9 +2786,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -2795,9 +2843,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -2842,9 +2893,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -2891,9 +2945,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -2938,9 +2995,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -2987,9 +3047,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -3034,9 +3097,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -3083,9 +3149,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -3135,9 +3204,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -853,9 +853,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -868,9 +871,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -886,9 +892,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -901,9 +910,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -919,9 +931,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -941,9 +956,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachineClusterPreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
@@ -2428,9 +2446,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -2443,9 +2464,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -2461,9 +2485,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -2476,9 +2503,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -2494,9 +2524,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -2516,9 +2549,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop

--- a/common-instancetypes/preferences/alpine/kustomization.yaml
+++ b/common-instancetypes/preferences/alpine/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../components/diskbus-virtio-blk
   - ../components/interfacemodel-virtio-net
 

--- a/common-instancetypes/preferences/alpine/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/alpine/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/alpine/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/alpine/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,alpine"
+    iconClass: "icon-alpine"
+    openshift.io/display-name: "Alpine"

--- a/common-instancetypes/preferences/base/kustomization.yaml
+++ b/common-instancetypes/preferences/base/kustomization.yaml
@@ -1,6 +1,10 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ./VirtualMachineClusterPreference.yaml
   - ./VirtualMachinePreference.yaml
+
+components:
+  - ./metadata

--- a/common-instancetypes/preferences/base/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/base/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/base/metadata/metadata.yaml
@@ -7,3 +7,5 @@ metadata:
     openshift.io/provider-display-name: "KubeVirt"
     openshift.io/documentation-url: "https://github.com/kubevirt/common-instancetypes"
     openshift.io/support-url: "https://github.com/kubevirt/common-instancetypes/issues"
+  labels:
+    instancetype.kubevirt.io/os-type: "linux"

--- a/common-instancetypes/preferences/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/base/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/provider-display-name: "KubeVirt"
+    openshift.io/documentation-url: "https://github.com/kubevirt/common-instancetypes"
+    openshift.io/support-url: "https://github.com/kubevirt/common-instancetypes/issues"

--- a/common-instancetypes/preferences/centos/7/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/7/kustomization.yaml
@@ -3,4 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+
+components:
+  - ./metadata
+
 nameSuffix: ".7"

--- a/common-instancetypes/preferences/centos/7/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/7/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/centos/7/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/centos/7/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "CentOS 7"

--- a/common-instancetypes/preferences/centos/8_stream/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/8_stream/kustomization.yaml
@@ -5,4 +5,7 @@ kind: Kustomization
 resources:
   - ../base
 
+components:
+  - ./metadata
+
 nameSuffix: ".8.stream"

--- a/common-instancetypes/preferences/centos/8_stream/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/8_stream/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/centos/8_stream/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/centos/8_stream/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "CentOS Stream 8"

--- a/common-instancetypes/preferences/centos/9_stream/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/9_stream/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 nameSuffix: ".9.stream"
 
 components:
+  - ./metadata
   - ../../components/rng
   - ../../components/secureboot
   - ../../components/disk-dedicatediothread

--- a/common-instancetypes/preferences/centos/9_stream/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/9_stream/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/centos/9_stream/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/centos/9_stream/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "CentOS Stream 9"

--- a/common-instancetypes/preferences/centos/base/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
 

--- a/common-instancetypes/preferences/centos/base/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/centos/base/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/centos/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/centos/base/metadata/metadata.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux,centos-stream"
+    iconClass: "icon-centos"

--- a/common-instancetypes/preferences/cirros/kustomization.yaml
+++ b/common-instancetypes/preferences/cirros/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../components/diskbus-virtio-blk
   - ../components/interfacemodel-virtio-net
 

--- a/common-instancetypes/preferences/cirros/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/cirros/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/cirros/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/cirros/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,cirros"
+    iconClass: "icon-cirros"
+    openshift.io/display-name: "Cirros"

--- a/common-instancetypes/preferences/fedora/kustomization.yaml
+++ b/common-instancetypes/preferences/fedora/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../components/diskbus-virtio-blk
   - ../components/interfacemodel-virtio-net
   - ../components/rng

--- a/common-instancetypes/preferences/fedora/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/fedora/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/fedora/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/fedora/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/display-name: "Fedora"

--- a/common-instancetypes/preferences/rhel/7/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/7/kustomization.yaml
@@ -5,4 +5,7 @@ kind: Kustomization
 resources:
   - ../base
 
+components:
+  - ./metadata
+
 nameSuffix: ".7"

--- a/common-instancetypes/preferences/rhel/7/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/7/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/rhel/7/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/rhel/7/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 7"

--- a/common-instancetypes/preferences/rhel/8/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/8/kustomization.yaml
@@ -5,4 +5,7 @@ kind: Kustomization
 resources:
   - ../base
 
+components:
+  - ./metadata
+
 nameSuffix: ".8"

--- a/common-instancetypes/preferences/rhel/8/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/8/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/rhel/8/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/rhel/8/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 8"

--- a/common-instancetypes/preferences/rhel/9/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/9/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 nameSuffix: ".9"
 
 components:
+  - ./metadata
   - ../../components/disk-dedicatediothread
   - ../../components/rng
   - ../../components/secureboot

--- a/common-instancetypes/preferences/rhel/9/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/9/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/rhel/9/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/rhel/9/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9"

--- a/common-instancetypes/preferences/rhel/base/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
 

--- a/common-instancetypes/preferences/rhel/base/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/rhel/base/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/rhel/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/rhel/base/metadata/metadata.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux,rhel"
+    iconClass: "icon-rhel"

--- a/common-instancetypes/preferences/ubuntu/kustomization.yaml
+++ b/common-instancetypes/preferences/ubuntu/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../components/diskbus-virtio-blk
   - ../components/interfacemodel-virtio-net
   - ../components/rng

--- a/common-instancetypes/preferences/ubuntu/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/ubuntu/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/ubuntu/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/ubuntu/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,ubuntu"
+    iconClass: "icon-ubuntu"
+    openshift.io/display-name: "Ubuntu"

--- a/common-instancetypes/preferences/windows/10/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/10/kustomization.yaml
@@ -1,6 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../base
+
+components:
+  - ./metadata
+
 nameSuffix: ".10"

--- a/common-instancetypes/preferences/windows/10/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/10/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/10/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/10/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10"

--- a/common-instancetypes/preferences/windows/10_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/10_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../10
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/10_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/10_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/10_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/10_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 10 (virtio)"

--- a/common-instancetypes/preferences/windows/11/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/11/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../../components/tpm
   - ../../components/secureboot

--- a/common-instancetypes/preferences/windows/11/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/11/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/11/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/11/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 11"

--- a/common-instancetypes/preferences/windows/11_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/11_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../11
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/11_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/11_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/11_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/11_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows 11"

--- a/common-instancetypes/preferences/windows/2k12/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k12/kustomization.yaml
@@ -1,6 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../base
+
+components:
+  - ./metadata
+
 nameSuffix: .2k12

--- a/common-instancetypes/preferences/windows/2k12/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k12/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k12/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k12/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012"

--- a/common-instancetypes/preferences/windows/2k12_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k12_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../2k12
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/2k12_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k12_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k12_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k12_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2012 (virtio)"

--- a/common-instancetypes/preferences/windows/2k16/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k16/kustomization.yaml
@@ -1,6 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../base
+
+components:
+  - ./metadata
+
 nameSuffix: .2k16

--- a/common-instancetypes/preferences/windows/2k16/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k16/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k16/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k16/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016"

--- a/common-instancetypes/preferences/windows/2k16_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k16_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../2k16
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/2k16_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k16_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k16_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k16_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2016 (virtio)"

--- a/common-instancetypes/preferences/windows/2k19/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k19/kustomization.yaml
@@ -1,6 +1,11 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
   - ../base
+
+components:
+  - ./metadata
+
 nameSuffix: .2k19

--- a/common-instancetypes/preferences/windows/2k19/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k19/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k19/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k19/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019"

--- a/common-instancetypes/preferences/windows/2k19_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k19_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../2k19
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/2k19_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k19_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k19_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k19_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2019"

--- a/common-instancetypes/preferences/windows/2k22/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k22/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../base
 
 components:
+  - ./metadata
   - ../../components/tpm
   - ../../components/secureboot
 

--- a/common-instancetypes/preferences/windows/2k22/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k22/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k22/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k22/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2022"

--- a/common-instancetypes/preferences/windows/2k22_virtio/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k22_virtio/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../2k22
 
 components:
+  - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio

--- a/common-instancetypes/preferences/windows/2k22_virtio/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k22_virtio/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/2k22_virtio/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k22_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2022 (virtio)"

--- a/common-instancetypes/preferences/windows/base/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
 
 components:
+  - ./metadata
   - ../../components/hyperv
   - ../../components/cpu-topology-sockets
   - ../../components/diskbus-sata

--- a/common-instancetypes/preferences/windows/base/metadata/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/base/metadata/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/common-instancetypes/preferences/windows/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/base/metadata/metadata.yaml
@@ -6,3 +6,5 @@ metadata:
   annotations:
     tags: "hidden,kubevirt,windows"
     iconClass: "icon-windows"
+  labels:
+    instancetype.kubevirt.io/os-type: "windows"

--- a/common-instancetypes/preferences/windows/base/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/base/metadata/metadata.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1alpha1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,windows"
+    iconClass: "icon-windows"

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -396,7 +396,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 10
+    openshift.io/display-name: Microsoft Windows 10 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -610,7 +610,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2012
+    openshift.io/display-name: Microsoft Windows Server 2012 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -712,7 +712,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2016
+    openshift.io/display-name: Microsoft Windows Server 2016 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -921,7 +921,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2022
+    openshift.io/display-name: Microsoft Windows Server 2022 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -18,9 +18,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -33,9 +36,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -51,9 +57,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -66,9 +75,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -84,9 +96,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -106,9 +121,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-centos
+    openshift.io/display-name: CentOS Stream 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,centos-stream
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -333,9 +333,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -380,9 +383,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 10
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -429,9 +435,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -481,9 +490,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows 11
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -535,9 +547,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -582,9 +597,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2012
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -631,9 +649,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -678,9 +699,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2016
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -727,9 +751,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -774,9 +801,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2019
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -823,9 +853,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -875,9 +908,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-windows
+    openshift.io/display-name: Microsoft Windows Server 2022
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,windows
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -10,6 +10,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,alpine
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
 spec:
@@ -28,6 +29,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
 spec:
@@ -46,6 +48,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
 spec:
@@ -67,6 +70,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
 spec:
@@ -85,6 +89,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
 spec:
@@ -106,6 +111,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
 spec:
@@ -131,6 +137,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,centos-stream
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
 spec:
@@ -159,6 +166,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,cirros
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
 spec:
@@ -177,6 +185,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,fedora
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
 spec:
@@ -202,6 +211,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
 spec:
@@ -220,6 +230,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
 spec:
@@ -241,6 +252,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
 spec:
@@ -259,6 +271,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
 spec:
@@ -280,6 +293,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
 spec:
@@ -305,6 +319,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,linux,rhel
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
 spec:
@@ -333,6 +348,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,ubuntu
   labels:
+    instancetype.kubevirt.io/os-type: linux
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
 spec:
@@ -352,6 +368,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
 spec:
@@ -402,6 +419,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
 spec:
@@ -454,6 +472,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
 spec:
@@ -509,6 +528,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
 spec:
@@ -566,6 +586,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
 spec:
@@ -616,6 +637,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
 spec:
@@ -668,6 +690,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
 spec:
@@ -718,6 +741,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
 spec:
@@ -770,6 +794,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
 spec:
@@ -820,6 +845,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
 spec:
@@ -872,6 +898,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
 spec:
@@ -927,6 +954,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio
 spec:

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -320,9 +320,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-ubuntu
+    openshift.io/display-name: Ubuntu
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,ubuntu
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -3,9 +3,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-alpine
+    openshift.io/display-name: Alpine
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,alpine
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -164,9 +164,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-fedora
+    openshift.io/display-name: Fedora
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,fedora
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -186,9 +186,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -201,9 +204,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 7
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -219,9 +225,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -234,9 +243,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 8
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -252,9 +264,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -274,9 +289,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-rhel
+    openshift.io/display-name: Red Hat Enterprise Linux 9
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,linux,rhel
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -152,9 +152,12 @@ apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
   annotations:
+    iconClass: icon-cirros
+    openshift.io/display-name: Cirros
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
+    tags: hidden,kubevirt,cirros
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -2,6 +2,10 @@
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: alpine
@@ -13,6 +17,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7
@@ -24,6 +32,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.7.desktop
@@ -38,6 +50,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream
@@ -49,6 +65,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.8.stream.desktop
@@ -63,6 +83,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream
@@ -81,6 +105,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: centos.9.stream.desktop
@@ -102,6 +130,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cirros
@@ -113,6 +145,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: fedora
@@ -131,6 +167,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7
@@ -142,6 +182,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.7.desktop
@@ -156,6 +200,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8
@@ -167,6 +215,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.8.desktop
@@ -181,6 +233,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9
@@ -199,6 +255,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: rhel.9.desktop
@@ -220,6 +280,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: ubuntu
@@ -232,6 +296,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10
@@ -275,6 +343,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.10.virtio
@@ -320,6 +392,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11
@@ -368,6 +444,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.11.virtio
@@ -418,6 +498,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -461,6 +545,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -506,6 +594,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16
@@ -549,6 +641,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k16.virtio
@@ -594,6 +690,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19
@@ -637,6 +737,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k19.virtio
@@ -682,6 +786,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22
@@ -730,6 +838,10 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1alpha2
 kind: VirtualMachinePreference
 metadata:
+  annotations:
+    openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
+    openshift.io/provider-display-name: KubeVirt
+    openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
   labels:
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k22.virtio


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OpenShift specific metadata has been introduced to all `VirtualMachinePreference` and `VirtualMachineClusterPreference` resources.

A new `instancetype.kubevirt.io/os-type` label has also been introduced allowing users to query for preferences that match the underlying OS type of their workload.
```
