### PR TITLE
Drop use of dedicatedCPUPlacement

### DIFF
--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -8,7 +8,6 @@ metadata:
   name: highperformance.large
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 2
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -24,7 +23,6 @@ metadata:
   name: highperformance.medium
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -40,7 +38,6 @@ metadata:
   name: highperformance.small
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -8,7 +8,6 @@ metadata:
   name: highperformance.large
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 2
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -24,7 +23,6 @@ metadata:
   name: highperformance.medium
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -40,7 +38,6 @@ metadata:
   name: highperformance.small
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -899,7 +896,6 @@ metadata:
   name: highperformance.large
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 2
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -915,7 +911,6 @@ metadata:
   name: highperformance.medium
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -931,7 +926,6 @@ metadata:
   name: highperformance.small
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -8,7 +8,6 @@ metadata:
   name: highperformance.large
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 2
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -24,7 +23,6 @@ metadata:
   name: highperformance.medium
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared
@@ -40,7 +38,6 @@ metadata:
   name: highperformance.small
 spec:
   cpu:
-    dedicatedCPUPlacement: true
     guest: 1
     isolateEmulatorThread: true
   ioThreadsPolicy: shared

--- a/common-instancetypes/instancetypes/legacy/highperformance/base/highperformance.yaml
+++ b/common-instancetypes/instancetypes/legacy/highperformance/base/highperformance.yaml
@@ -7,4 +7,3 @@ spec:
   ioThreadsPolicy: shared
   cpu:
     isolateEmulatorThread: true
-    dedicatedCPUPlacement: true


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent change to KubeVirt [1][2] has essentially disabled the use of dedicatedCPUPlacement as we have no way of expressing the required resource requirements through instance types at present.

Until this is corrected all requests to create instance types with this attribute will be rejected. This change drops the use of this attribute until this is resolved.

[1] https://github.com/kubevirt/kubevirt/pull/8886 
[2] https://github.com/kubevirt/kubevirt/issues/8867


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The use of `dedicatedCPUPlacement` has been dropped until support for resource requests is introduced to instance types.
```
