### PR TITLE
check: Check if safe.directory is already configured before adding an entry

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # We need to add the current directory as a safe git directory before running any commands
-git config --global --add safe.directory "$(pwd)"
+if ! git config --global --get-all safe.directory | grep "$(pwd)" > /dev/null; then
+    git config --global --add safe.directory "$(pwd)"
+fi
 
-git diff --quiet common*.yaml README.md
-uncommited=$?
-if [[ $uncommited -eq 1 ]]; then
+if ! git diff --quiet common*.yaml README.md; then
     echo "Uncommited changes to generated files present, please commit these and try again."
     git --no-pager diff  common*.yaml README.md
     exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

`git config --global --add` will always add a new line to `safe.directory` when called so check if it's actually required before calling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
