### PR TITLE
github: Add release update task for SSP operator

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,48 @@ jobs:
             cp ${f} ${f/\.yaml/-${{ github.ref_name }}\.yaml}
           done
       - name: Release
+        id: release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             *bundle-${{ github.ref_name }}.yaml
             LICENSE
+      - name: Update SSP Operator
+        run: |
+          # Define vars
+          export VERSION="${{ github.ref_name }}"
+          export RELEASE_FORK_USER=lyarwood
+
+          # Set git configs to sign the commit
+          git config --global user.email "${RELEASE_FORK_USER}@redhat.com"
+          git config --global user.name "common-instancetypes Release Automation"
+
+          # Clone repo and use a token to allow pushing before creating a PR
+          git clone https://github.com/kubevirt/ssp-operator && cd ssp-operator
+          git checkout origin/master -b update-common-instancetypes-${VERSION}
+
+          # Update the new common-instancetypes file
+          cp ../common-clusterinstancetypes-bundle.yaml data/common-instancetypes-bundle/
+          cp ../common-clusterpreferences-bundle.yaml data/common-instancetypes-bundle/
+          git add data && git commit -sm "common-instancetypes: Update bundle to version ${VERSION}"
+
+          git remote add release https://${RELEASE_FORK_USER}:${{ secrets.RELEASE_FORK_TOKEN }}@github.com/${RELEASE_FORK_USER}/ssp-operator
+          git push -f -u release update-common-instancetypes-${VERSION}
+
+          # Create a new PR in the operator repo
+          GH_TOKEN=${{ secrets.RELEASE_FORK_TOKEN }} gh pr create --repo kubevirt/ssp-operator \
+            --base master \
+            --head ${RELEASE_FORK_USER}:update-common-instancetypes-${VERSION} \
+            --title "Update common-instancetypes to ${VERSION}" \
+            --body "$(cat << EOF
+          common-instancetypes: Update bundle to ${VERSION}
+
+          ${{ steps.release.outputs.url }}
+
+          **Release note**:
+          \`\`\`release-note
+          Update common-instancetypes bundle to ${VERSION}
+          \`\`\`
+          EOF
+          )
+          "


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

This change introduces an additional step to the release workflow, creating a PR within the `kubevirt/ssp-operator` project importing the updated bundles of cluster resources. This was previously force merged and ran below:

https://github.com/kubevirt/common-instancetypes/actions/runs/3904777026

https://github.com/kubevirt/ssp-operator/pull/481

I've pulled the commit out and into a PR for a formal review. In future it would be nice to somehow support testing these workflows through tools like [`act`](https://github.com/nektos/act) but I couldn't get it to work for me this time around.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tagged releases of `common-instancetypes` now have any changes to the generated cluster resources sync'd into the `kubevirt/ssp-operator` project.
```
