### PR TITLE
CX: Remove `guestMappingPassthrough`

### DIFF
--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -24,8 +24,6 @@ spec:
   cpu:
     guest: 8
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -55,8 +53,6 @@ spec:
   cpu:
     guest: 16
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -86,8 +82,6 @@ spec:
   cpu:
     guest: 32
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -117,8 +111,6 @@ spec:
   cpu:
     guest: 2
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -148,8 +140,6 @@ spec:
   cpu:
     guest: 1
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -179,8 +169,6 @@ spec:
   cpu:
     guest: 4
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -24,8 +24,6 @@ spec:
   cpu:
     guest: 8
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -55,8 +53,6 @@ spec:
   cpu:
     guest: 16
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -86,8 +82,6 @@ spec:
   cpu:
     guest: 32
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -117,8 +111,6 @@ spec:
   cpu:
     guest: 2
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -148,8 +140,6 @@ spec:
   cpu:
     guest: 1
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -179,8 +169,6 @@ spec:
   cpu:
     guest: 4
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi
@@ -1693,8 +1681,6 @@ spec:
   cpu:
     guest: 8
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -1724,8 +1710,6 @@ spec:
   cpu:
     guest: 16
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -1755,8 +1739,6 @@ spec:
   cpu:
     guest: 32
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -1786,8 +1768,6 @@ spec:
   cpu:
     guest: 2
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -1817,8 +1797,6 @@ spec:
   cpu:
     guest: 1
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -1848,8 +1826,6 @@ spec:
   cpu:
     guest: 4
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -24,8 +24,6 @@ spec:
   cpu:
     guest: 8
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -55,8 +53,6 @@ spec:
   cpu:
     guest: 16
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -86,8 +82,6 @@ spec:
   cpu:
     guest: 32
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -117,8 +111,6 @@ spec:
   cpu:
     guest: 2
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -148,8 +140,6 @@ spec:
   cpu:
     guest: 1
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -179,8 +169,6 @@ spec:
   cpu:
     guest: 4
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi

--- a/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
@@ -19,6 +19,4 @@ metadata:
 spec:
   cpu:
     isolateEmulatorThread: true
-    numa:
-      guestMappingPassthrough: {}
   ioThreadsPolicy: "auto"


### PR DESCRIPTION
**What this PR does / why we need it**:

Instance types using dedicatedCPUPlacement have recently started to be rejected by virt-api [1] as we currently have no way of expressing the required resource requests within an instance type.

dedicatedCPUPlacement is also a requirement when using guestMappingPassthrough and as such this also needs to be removed from our shipped instance types ahead of a similar check being introduced [2] in virt-api.

[1] https://github.com/kubevirt/kubevirt/pull/8886 
[2] https://github.com/kubevirt/kubevirt/pull/9105

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The use of `guestMappingPassthrough` has been dropped until support for `dedicatedCPUPlacement` and resource requests is introduced to instance types.
```
