### PR TITLE
CX,M,Highperf: Remove IsolateEmulatorThread

### DIFF
--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -23,7 +23,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -52,7 +51,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -81,7 +79,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -110,7 +107,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -139,7 +135,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -168,7 +163,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi
@@ -295,7 +289,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 8Gi
@@ -310,7 +303,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 4Gi
@@ -325,7 +317,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 2Gi
@@ -347,7 +338,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   memory:
     guest: 64Gi
     hugepages:
@@ -370,7 +360,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   memory:
     guest: 128Gi
     hugepages:
@@ -393,7 +382,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   memory:
     guest: 256Gi
     hugepages:
@@ -416,7 +404,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   memory:
     guest: 16Gi
     hugepages:
@@ -439,7 +426,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   memory:
     guest: 32Gi
     hugepages:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -23,7 +23,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -52,7 +51,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -81,7 +79,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -110,7 +107,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -139,7 +135,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -168,7 +163,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi
@@ -295,7 +289,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 8Gi
@@ -310,7 +303,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 4Gi
@@ -325,7 +317,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 2Gi
@@ -347,7 +338,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   memory:
     guest: 64Gi
     hugepages:
@@ -370,7 +360,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   memory:
     guest: 128Gi
     hugepages:
@@ -393,7 +382,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   memory:
     guest: 256Gi
     hugepages:
@@ -416,7 +404,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   memory:
     guest: 16Gi
     hugepages:
@@ -439,7 +426,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   memory:
     guest: 32Gi
     hugepages:
@@ -1680,7 +1666,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -1709,7 +1694,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -1738,7 +1722,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -1767,7 +1750,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -1796,7 +1778,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -1825,7 +1806,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi
@@ -1952,7 +1932,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 8Gi
@@ -1967,7 +1946,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 4Gi
@@ -1982,7 +1960,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 2Gi
@@ -2004,7 +1981,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   memory:
     guest: 64Gi
     hugepages:
@@ -2027,7 +2003,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   memory:
     guest: 128Gi
     hugepages:
@@ -2050,7 +2025,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   memory:
     guest: 256Gi
     hugepages:
@@ -2073,7 +2047,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   memory:
     guest: 16Gi
     hugepages:
@@ -2096,7 +2069,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   memory:
     guest: 32Gi
     hugepages:

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -23,7 +23,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 16Gi
@@ -52,7 +51,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 32Gi
@@ -81,7 +79,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 64Gi
@@ -110,7 +107,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 4Gi
@@ -139,7 +135,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 2Gi
@@ -168,7 +163,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   ioThreadsPolicy: auto
   memory:
     guest: 8Gi
@@ -295,7 +289,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 8Gi
@@ -310,7 +303,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 4Gi
@@ -325,7 +317,6 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
   ioThreadsPolicy: shared
   memory:
     guest: 2Gi
@@ -347,7 +338,6 @@ metadata:
 spec:
   cpu:
     guest: 8
-    isolateEmulatorThread: true
   memory:
     guest: 64Gi
     hugepages:
@@ -370,7 +360,6 @@ metadata:
 spec:
   cpu:
     guest: 16
-    isolateEmulatorThread: true
   memory:
     guest: 128Gi
     hugepages:
@@ -393,7 +382,6 @@ metadata:
 spec:
   cpu:
     guest: 32
-    isolateEmulatorThread: true
   memory:
     guest: 256Gi
     hugepages:
@@ -416,7 +404,6 @@ metadata:
 spec:
   cpu:
     guest: 2
-    isolateEmulatorThread: true
   memory:
     guest: 16Gi
     hugepages:
@@ -439,7 +426,6 @@ metadata:
 spec:
   cpu:
     guest: 4
-    isolateEmulatorThread: true
   memory:
     guest: 32Gi
     hugepages:

--- a/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
@@ -17,6 +17,10 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/class: "Compute Exclusive"
 spec:
-  cpu:
-    isolateEmulatorThread: true
   ioThreadsPolicy: "auto"
+  # FIXME(lyarwood): Reintroduce once we can use dedicatedCPUPlacement again
+  # cpu:
+  #  isolateEmulatorThread: true
+  #  dedicatedCPUPlacement: true
+  #  numa:
+  #    guestMappingPassthrough: {}

--- a/common-instancetypes/instancetypes/hyperscale/m/base/m.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/base/m.yaml
@@ -13,7 +13,10 @@ metadata:
 spec:
   cpu:
     guest: 1
-    isolateEmulatorThread: true
+  # FIXME(lyarwood): Reintroduce once we can use DedicatedCPUPlacement again
+  # cpu:
+  #  isolateEmulatorThread: true
+  #  dedicatedCPUPlacement: true
   memory:
     guest: 1Gi
     hugepages:

--- a/common-instancetypes/instancetypes/legacy/highperformance/base/highperformance.yaml
+++ b/common-instancetypes/instancetypes/legacy/highperformance/base/highperformance.yaml
@@ -5,5 +5,7 @@ metadata:
   name: highperformance
 spec:
   ioThreadsPolicy: shared
-  cpu:
-    isolateEmulatorThread: true
+  # FIXME(lyarwood): Reintroduce once we can use DedicatedCPUPlacement again
+  # cpu:
+  #  isolateEmulatorThread: true
+  #  dedicatedCPUPlacement: true


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

This is yet more fallout from DedicatedCPUPlacement being unsupported. IsolateEmulatorThread requires DedicatedCPUPlacement and is removed until we can support the latter.

A TODO is added listing the attributes to add back in once this support lands in KubeVirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
