### PR TITLE
Add kubevirtci deployment support and functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/*
+.history
+.idea
+_cluster-up/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .history
 .idea
 _cluster-up/
+_kubevirt/

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,18 @@ readme:
 check:
 	./scripts/cri.sh  "./scripts/check.sh"
 
+.PHONY: cluster-up
+cluster-up:
+	./scripts/kubevirtci.sh up
+
+.PHONY: cluster-down
+cluster-down:
+	./scripts/kubevirtci.sh down
+
+.PHONY: cluster-sync
+cluster-sync:
+	./scripts/kubevirtci.sh sync
+
 clean: 
 	rm -f common*.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ cluster-down:
 cluster-sync:
 	./scripts/kubevirtci.sh sync
 
+.PHONY: cluster-functest
+cluster-functest:
+	./scripts/kubevirtci.sh functest
+
 .PHONY: kubevirt-up
 kubevirt-up:
 	./scripts/kubevirt.sh up
@@ -57,6 +61,10 @@ kubevirt-down:
 .PHONY: kubevirt-sync
 kubevirt-sync:
 	./scripts/kubevirt.sh sync
+
+.PHONY: kubevirt-functest
+kubevirt-functest:
+	./scripts/kubevirt.sh functest
 
 clean: 
 	rm -f common*.yaml

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,18 @@ cluster-down:
 cluster-sync:
 	./scripts/kubevirtci.sh sync
 
+.PHONY: kubevirt-up
+kubevirt-up:
+	./scripts/kubevirt.sh up
+
+.PHONY: kubevirt-down
+kubevirt-down:
+	./scripts/kubevirt.sh down
+
+.PHONY: kubevirt-sync
+kubevirt-sync:
+	./scripts/kubevirt.sh sync
+
 clean: 
 	rm -f common*.yaml
 

--- a/scripts/functest.sh
+++ b/scripts/functest.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${KUBECTL}" ]; then
+    echo "${BASH_SOURCE[0]} expects the following env variables to be provided: KUBECTL."
+    exit 1
+fi
+
+# This func test simply loops over the installed instance types and preferences, assigning each to a VirtualMachine to ensure they are accepted by the webhooks
+for preference in $(${KUBECTL} get virtualmachineclusterpreferences --no-headers -o custom-columns=':metadata.name'); do
+    # TODO(lyarwood): Replace with virtctl create vm once 0.59.0 is released
+    # ${VIRTCTL} create vm --preference ${preference}
+    ${KUBECTL} apply -f - << EOF
+---    
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-${preference}
+spec:
+  preference:
+    name: ${preference}
+  running: false
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes:
+      - containerDisk:
+          image: quay.io/containerdisks/fedora:37
+        name: containerdisk
+EOF
+    # We can't inline the above creation call below so stash the return code and check it to keep shellcheck happy
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "functest failed on preference ${preference}"
+        exit 1
+    fi
+    ${KUBECTL} delete "vm/vm-${preference}"
+done
+
+for instancetype in $(${KUBECTL} get virtualmachineclusterinstancetypes --no-headers -o custom-columns=':metadata.name'); do
+    # TODO(lyarwood): Replace with virtctl create vm once 0.59.0 is released
+    # ${VIRTCTL} create vm --instance-type ${instancetype}
+    ${KUBECTL} apply -f - << EOF
+---    
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-${instancetype}
+spec:
+  instancetype:
+    name: ${instancetype}
+  running: false
+  template:
+    spec:
+      domain:
+        devices: {}
+      volumes:
+      - containerDisk:
+          image: quay.io/containerdisks/fedora:37
+        name: containerdisk
+EOF
+    # We can't inline the above creation call below so stash the return code and check it to keep shellcheck happy
+    ret=$?
+    if [ $ret -ne 0 ]; then
+        echo "functest failed on instance type ${instancetype}"
+        exit 1
+    fi
+    ${KUBECTL} delete "vm/vm-${instancetype}"
+done

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -49,6 +49,10 @@ function kubevirt::registry() {
   echo "localhost:${port}"
 }
 
+function kubevirtci::functest() {
+  KUBECTL=${_kubectl} "${_base_dir}/scripts/functest.sh"
+}
+
 kubevirt::install
 
 case ${_action} in
@@ -73,8 +77,11 @@ case ${_action} in
   "kubectl")
     ${_kubectl} "$@"
     ;;
+  "functest")
+    kubevirtci::functest
+    ;;
   *)
-    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl', 'functest'"
     exit 1
     ;;
 esac

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export KUBEVIRT_TAG="${KUBEVIRT_TAG:-main}"
+
+_base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+_kubectl="${_base_dir}/_kubevirt/cluster-up/kubectl.sh"
+_kubessh="${_base_dir}/_kubevirt/cluster-up/ssh.sh"
+_kubevirtcicli="${_base_dir}/_kubevirt/cluster-up/cli.sh"
+_action=$1
+shift
+
+function kubevirt::install() {
+  if [[ ! -d ${_base_dir}/_kubevirt ]]; then
+    git clone --depth 1 --branch "${KUBEVIRT_TAG}" https://github.com/kubevirt/kubevirt.git "${_base_dir}/_kubevirt"
+  fi
+}
+
+function kubevirt::up() {
+  make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
+
+  echo "enabling the GPU feature gate to validate the GN instance types"
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU"]}}}}'
+}
+
+function kubevirt::down() {
+  make cluster-down -C "${_base_dir}/_kubevirt"
+}
+
+function kubevirt::kubeconfig() {
+  "${_base_dir}/_kubevirt/cluster-up/kubeconfig.sh"
+}
+
+function kubevirt::registry() {
+  port=$(${_kubevirtcicli} ports registry 2>/dev/null)
+  echo "localhost:${port}"
+}
+
+kubevirt::install
+
+case ${_action} in
+  "up")
+    kubevirt::up
+    ;;
+  "down")
+    kubevirt::down
+    ;;
+  "sync")
+    KUBECTL=${_kubectl} "${_base_dir}/scripts/sync.sh"
+    ;;
+  "ssh")
+    ${_kubessh} "$@"
+    ;;
+  "kubeconfig")
+    kubevirt::kubeconfig
+    ;;
+  "registry")
+    kubevirt::registry
+    ;;
+  "kubectl")
+    ${_kubectl} "$@"
+    ;;
+  *)
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
+    exit 1
+    ;;
+esac
+

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)}
+export KUBEVIRT_DEPLOY_CDI="true"
+
+_base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+_cluster_up_dir="${_base_dir}/_cluster-up"
+_kubectl="${_cluster_up_dir}/cluster-up/kubectl.sh"
+_kubessh="${_cluster_up_dir}/cluster-up/ssh.sh"
+_kubevirtcicli="${_cluster_up_dir}/cluster-up/cli.sh"
+_action=$1
+shift
+
+function kubevirtci::fetch_kubevirtci() {
+	if [[ ! -d ${_cluster_up_dir} ]]; then
+    git clone --depth 1 --branch "${KUBEVIRTCI_TAG}" https://github.com/kubevirt/kubevirtci.git "${_cluster_up_dir}"
+  fi
+}
+
+function kubevirtci::up() {
+  make cluster-up -C "${_cluster_up_dir}"
+  KUBECONFIG=$(kubevirtci::kubeconfig)
+  export KUBECONFIG
+  echo "adding kubevirtci registry to cdi-insecure-registries"
+  ${_kubectl} patch configmap cdi-insecure-registries -n cdi --type merge -p '{"data":{"kubevirtci": "registry:5000"}}'
+  echo "installing kubevirt..."
+  LATEST=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)
+  ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml"
+  ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-cr.yaml"
+  echo "waiting for kubevirt to become ready, this can take a few minutes..."
+  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
+  echo "enabling the GPU feature gate to validate the GN instance types"
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU"]}}}}'
+}
+
+function kubevirtci::down() {
+  make cluster-down -C "${_cluster_up_dir}"
+}
+
+function kubevirtci::registry() {
+  port=$(${_kubevirtcicli} ports registry 2>/dev/null)
+  echo "localhost:${port}"
+}
+
+function kubevirtci::sync() {
+  KUBECTL=${_kubectl} "${_base_dir}/scripts/sync.sh"
+}
+
+function kubevirtci::kubeconfig() {
+  "${_cluster_up_dir}/cluster-up/kubeconfig.sh"
+}
+
+kubevirtci::fetch_kubevirtci
+
+case ${_action} in
+  "up")
+    kubevirtci::up
+    ;;
+  "down")
+    kubevirtci::down
+    ;;
+  "sync")
+    kubevirtci::sync
+    ;;
+  "ssh")
+    ${_kubessh} "$@"
+    ;;
+  "kubeconfig")
+    kubevirtci::kubeconfig
+    ;;
+  "registry")
+    kubevirtci::registry
+    ;;
+  "kubectl")
+    ${_kubectl} "$@"
+    ;;
+  *)
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
+    exit 1
+    ;;
+esac

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -10,6 +10,6 @@ if ! command -v shellcheck &> /dev/null; then
     exit 1
 fi
 
-yamllint -d relaxed .
+yamllint -d relaxed ./common-instancetypes ./common-*.yaml
 
 shellcheck ./scripts/*

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${KUBECTL}" ]; then
+    echo "${BASH_SOURCE[0]} expects the following env variables to be provided: KUBECTL."
+    exit 1
+fi
+${KUBECTL} delete all -l instancetype.kubevirt.io/vendor=kubevirt.io
+${KUBECTL} kustomize ./VirtualMachineClusterInstancetypes | ${KUBECTL} apply -f -
+${KUBECTL} kustomize ./VirtualMachineClusterPreferences | ${KUBECTL} apply -f -


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

This PR adds kubevirtci and a simple set of functional tests to the project.

At present these tests are crudely written in bash and only exercise the admission the generated resources *and* the admission of a VirtualMachine referencing these resources. The latter is useful as it exercises the validation codepaths ensuring the common-instancetypes are actually useful.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Draft until https://github.com/kubevirt/common-instancetypes/pull/26 and https://github.com/kubevirt/kubevirt/pull/9103 land allowing the functional tests to pass.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
