### PR TITLE
Add resource labels to hyperscale instance types

### DIFF
--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -18,6 +18,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 16Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.2xlarge
 spec:
@@ -52,6 +58,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 32Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.4xlarge
 spec:
@@ -86,6 +98,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 64Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.8xlarge
 spec:
@@ -120,6 +138,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 4Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.large
 spec:
@@ -154,6 +178,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 2Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.medium
 spec:
@@ -188,6 +218,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 8Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.xlarge
 spec:
@@ -220,6 +256,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.2xlarge
 spec:
@@ -248,6 +287,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.4xlarge
 spec:
@@ -276,6 +318,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.8xlarge
 spec:
@@ -304,6 +349,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.xlarge
 spec:
@@ -378,6 +426,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.2xlarge
 spec:
@@ -400,6 +451,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.4xlarge
 spec:
@@ -422,6 +476,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.8xlarge
 spec:
@@ -444,6 +501,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.large
 spec:
@@ -466,6 +526,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.xlarge
 spec:
@@ -492,6 +555,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.2xlarge
 spec:
@@ -516,6 +581,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.4xlarge
 spec:
@@ -540,6 +607,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.8xlarge
 spec:
@@ -564,6 +633,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.large
 spec:
@@ -588,6 +659,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.medium
 spec:
@@ -612,6 +685,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.xlarge
 spec:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -18,6 +18,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 16Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.2xlarge
 spec:
@@ -52,6 +58,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 32Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.4xlarge
 spec:
@@ -86,6 +98,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 64Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.8xlarge
 spec:
@@ -120,6 +138,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 4Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.large
 spec:
@@ -154,6 +178,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 2Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.medium
 spec:
@@ -188,6 +218,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 8Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.xlarge
 spec:
@@ -220,6 +256,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.2xlarge
 spec:
@@ -248,6 +287,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.4xlarge
 spec:
@@ -276,6 +318,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.8xlarge
 spec:
@@ -304,6 +349,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.xlarge
 spec:
@@ -378,6 +426,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.2xlarge
 spec:
@@ -400,6 +451,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.4xlarge
 spec:
@@ -422,6 +476,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.8xlarge
 spec:
@@ -444,6 +501,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.large
 spec:
@@ -466,6 +526,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.xlarge
 spec:
@@ -492,6 +555,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.2xlarge
 spec:
@@ -516,6 +581,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.4xlarge
 spec:
@@ -540,6 +607,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.8xlarge
 spec:
@@ -564,6 +633,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.large
 spec:
@@ -588,6 +659,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.medium
 spec:
@@ -612,6 +685,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.xlarge
 spec:
@@ -709,6 +784,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 16Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.2xlarge
 spec:
@@ -743,6 +824,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 32Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.4xlarge
 spec:
@@ -777,6 +864,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 64Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.8xlarge
 spec:
@@ -811,6 +904,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 4Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.large
 spec:
@@ -845,6 +944,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 2Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.medium
 spec:
@@ -879,6 +984,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 8Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.xlarge
 spec:
@@ -911,6 +1022,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.2xlarge
 spec:
@@ -939,6 +1053,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.4xlarge
 spec:
@@ -967,6 +1084,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.8xlarge
 spec:
@@ -995,6 +1115,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.xlarge
 spec:
@@ -1069,6 +1192,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.2xlarge
 spec:
@@ -1091,6 +1217,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.4xlarge
 spec:
@@ -1113,6 +1242,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.8xlarge
 spec:
@@ -1135,6 +1267,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.large
 spec:
@@ -1157,6 +1292,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.xlarge
 spec:
@@ -1183,6 +1321,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.2xlarge
 spec:
@@ -1207,6 +1347,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.4xlarge
 spec:
@@ -1231,6 +1373,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.8xlarge
 spec:
@@ -1255,6 +1399,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.large
 spec:
@@ -1279,6 +1425,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.medium
 spec:
@@ -1303,6 +1451,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.xlarge
 spec:

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -18,6 +18,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 16Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.2xlarge
 spec:
@@ -52,6 +58,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 32Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.4xlarge
 spec:
@@ -86,6 +98,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 64Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.8xlarge
 spec:
@@ -120,6 +138,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 4Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.large
 spec:
@@ -154,6 +178,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 2Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.medium
 spec:
@@ -188,6 +218,12 @@ metadata:
       cores is provided to the VM.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/memory: 8Gi
+    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: cx1.xlarge
 spec:
@@ -220,6 +256,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.2xlarge
 spec:
@@ -248,6 +287,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.4xlarge
 spec:
@@ -276,6 +318,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.8xlarge
 spec:
@@ -304,6 +349,9 @@ metadata:
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: gn1.xlarge
 spec:
@@ -378,6 +426,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.2xlarge
 spec:
@@ -400,6 +451,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.4xlarge
 spec:
@@ -422,6 +476,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.8xlarge
 spec:
@@ -444,6 +501,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.large
 spec:
@@ -466,6 +526,9 @@ metadata:
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: m1.xlarge
 spec:
@@ -492,6 +555,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.2xlarge
 spec:
@@ -516,6 +581,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.4xlarge
 spec:
@@ -540,6 +607,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.8xlarge
 spec:
@@ -564,6 +633,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.large
 spec:
@@ -588,6 +659,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.medium
 spec:
@@ -612,6 +685,8 @@ metadata:
       time-slice basis with other VMs.
     instancetype.kubevirt.io/version: "1"
   labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: n1.xlarge
 spec:

--- a/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/base/cx.yaml
@@ -16,6 +16,11 @@ metadata:
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
     instancetype.kubevirt.io/class: "Compute Exclusive"
+  labels:
+    instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
+    instancetype.kubevirt.io/isolateEmulatorThread: "true"
+    instancetype.kubevirt.io/numa: "true"
+    instancetype.kubevirt.io/hugepages: "true"
 spec:
   cpu:
     dedicatedCPUPlacement: true

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/2xlarge/2xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/2xlarge/2xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "16Gi"
 spec:
   cpu:
     guest: 8

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/4xlarge/4xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/4xlarge/4xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx1"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "32Gi"
 spec:
   cpu:
     guest: 16

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/8xlarge/8xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/8xlarge/8xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx1"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "64Gi"
 spec:
   cpu:
     guest: 32

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/large/large.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/large/large.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "4Gi"
 spec:
   cpu:
     guest: 2

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/medium/medium.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/medium/medium.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx"
+  labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: "2Gi"
 spec:
   cpu:
     guest: 1

--- a/common-instancetypes/instancetypes/hyperscale/cx/sizes/xlarge/xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/cx/sizes/xlarge/xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "cx"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "8Gi"
 spec:
   cpu:
     guest: 4

--- a/common-instancetypes/instancetypes/hyperscale/gn/base/gn.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/gn/base/gn.yaml
@@ -15,6 +15,8 @@ metadata:
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
     instancetype.kubevirt.io/class: "GPU NVIDIA"
+  labels:
+    instancetype.kubevirt.io/gpus: "true"
 spec:
   gpus:
     - name: "gpu1"

--- a/common-instancetypes/instancetypes/hyperscale/gn/sizes/2xlarge/2xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/gn/sizes/2xlarge/2xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "gn"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "32Gi"
 spec:
   cpu:
     guest: 8

--- a/common-instancetypes/instancetypes/hyperscale/gn/sizes/4xlarge/4xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/gn/sizes/4xlarge/4xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "gn"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "64Gi"
 spec:
   cpu:
     guest: 16

--- a/common-instancetypes/instancetypes/hyperscale/gn/sizes/8xlarge/8xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/gn/sizes/8xlarge/8xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "gn"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "128Gi"
 spec:
   cpu:
     guest: 32

--- a/common-instancetypes/instancetypes/hyperscale/gn/sizes/xlarge/xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/gn/sizes/xlarge/xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "gn"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "16Gi"
 spec:
   cpu:
     guest: 4

--- a/common-instancetypes/instancetypes/hyperscale/m/base/m.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/base/m.yaml
@@ -10,6 +10,8 @@ metadata:
 
       *M* is the abbreviation of "Memory".
     instancetype.kubevirt.io/class: "Memory Intensive"
+  labels:
+    instancetype.kubevirt.io/hugepages: "true"
 spec:
   cpu:
     guest: 1

--- a/common-instancetypes/instancetypes/hyperscale/m/sizes/2xlarge/2xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/sizes/2xlarge/2xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "m"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "64Gi"
 spec:
   cpu:
     guest: 8

--- a/common-instancetypes/instancetypes/hyperscale/m/sizes/4xlarge/4xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/sizes/4xlarge/4xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "m"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "128Gi"
 spec:
   cpu:
     guest: 16

--- a/common-instancetypes/instancetypes/hyperscale/m/sizes/8xlarge/8xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/sizes/8xlarge/8xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "m"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "256Gi"
 spec:
   cpu:
     guest: 32

--- a/common-instancetypes/instancetypes/hyperscale/m/sizes/large/large.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/sizes/large/large.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "m"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "16Gi"
 spec:
   cpu:
     guest: 2

--- a/common-instancetypes/instancetypes/hyperscale/m/sizes/xlarge/xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/m/sizes/xlarge/xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "m"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "32Gi"
 spec:
   cpu:
     guest: 4

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/2xlarge/2xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/2xlarge/2xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "32Gi"
 spec:
   cpu:
     guest: 8

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/4xlarge/4xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/4xlarge/4xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "64Gi"
 spec:
   cpu:
     guest: 16

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/8xlarge/8xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/8xlarge/8xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "128Gi"
 spec:
   cpu:
     guest: 32

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/large/large.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/large/large.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "8Gi"
 spec:
   cpu:
     guest: 2

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/medium/medium.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/medium/medium.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: "4Gi"
 spec:
   cpu:
     guest: 1

--- a/common-instancetypes/instancetypes/hyperscale/n/sizes/xlarge/xlarge.yaml
+++ b/common-instancetypes/instancetypes/hyperscale/n/sizes/xlarge/xlarge.yaml
@@ -3,6 +3,9 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   name: "n"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "16Gi"
 spec:
   cpu:
     guest: 4


### PR DESCRIPTION
**What this PR does / why we need it**:

The following resource labels have been added to each hyperscale
instance type to aid users searching for a type with specific resources:

* instancetype.kubevirt.io/cpu    - Number of vCPUs
* instancetype.kubevirt.io/memory - Amount of RAM

Additionally the following optional bool labels have also been added to
relevant instance types to help users looking for more specific
resources and features:

* instancetype.kubevirt.io/dedicatedCPUPlacement
* instancetype.kubevirt.io/hugepages
* instancetype.kubevirt.io/isolateEmulatorThread
* instancetype.kubevirt.io/numa
* instancetype.kubevirt.io/gpus

For example:

```
$ ./cluster-up/kubectl.sh get virtualmachineclusterinstancetype -linstancetype.kubevirt.io/hugepages=true
selecting podman as container runtime
NAME          AGE
cx1.2xlarge   113s
cx1.4xlarge   113s
cx1.8xlarge   113s
cx1.large     113s
cx1.medium    113s
cx1.xlarge    113s
m1.2xlarge    113s
m1.4xlarge    113s
m1.8xlarge    113s
m1.large      113s
m1.xlarge     113s

$ ./cluster-up/kubectl.sh get virtualmachineclusterinstancetype -linstancetype.kubevirt.io/cpu=4
selecting podman as container runtime
NAME         AGE
cx1.xlarge   3m8s
gn1.xlarge   3m8s
m1.xlarge    3m8s
n1.xlarge    3m8s

$ ./cluster-up/kubectl.sh get virtualmachineclusterinstancetype -linstancetype.kubevirt.io/cpu=4,instancetype.kubevirt.io/hugepages=true
selecting podman as container runtime
NAME         AGE
cx1.xlarge   5m47s
m1.xlarge    5m47s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Resource labels have been introduced to each hyperscale instance type to aid users searching for instance types providing specific resources.
```
