### PR TITLE
github: Fix bundle version labelling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,12 @@ jobs:
           for f in $(ls *bundle.yaml); do
             cp ${f} ${f/\.yaml/-${VERSION}\.yaml}
           done
-          
+
           # Install yq and use it to update each resource with an instancetype.kubevirt.io/common-instancetypes-version annotation
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ./yq && chmod +X ./yq
-          yq -i '.metadata.annotations.["instancetype.kubevirt.io/common-instancetypes-version"]=env(VERSION)' *bundle-${VERSION}.yaml
+          for bundle in $(ls *bundle-${VERSION}.yaml); do
+            yq -i '.metadata.labels.["instancetype.kubevirt.io/common-instancetypes-version"]=env(VERSION)' ${bundle}
+          done
       - name: Release
         id: release
         uses: softprops/action-gh-release@v1
@@ -31,7 +33,7 @@ jobs:
         run: |
           # Define vars
           export VERSION="${{ github.ref_name }}"
-          export RELEASE_FORK_USER=lyarwood
+          RELEASE_FORK_USER=lyarwood
 
           # Set git configs to sign the commit
           git config --global user.email "${RELEASE_FORK_USER}@redhat.com"
@@ -44,6 +46,13 @@ jobs:
           # Update the new common-instancetypes file
           cp ../common-clusterinstancetypes-bundle.yaml data/common-instancetypes-bundle/
           cp ../common-clusterpreferences-bundle.yaml data/common-instancetypes-bundle/
+
+          # Install yq and use it to update each resource with an instancetype.kubevirt.io/common-instancetypes-version annotation
+          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ./yq && chmod +X ./yq
+          for bundle in $(ls data/common-instancetypes-bundle/bundle*.yaml); do
+            yq -i '.metadata.labels.["instancetype.kubevirt.io/common-instancetypes-version"]=env(VERSION)' ${bundle}
+          done
+
           git add data && git commit -sm "common-instancetypes: Update bundle to version ${VERSION}"
 
           git remote add release https://${RELEASE_FORK_USER}:${{ secrets.RELEASE_FORK_TOKEN }}@github.com/${RELEASE_FORK_USER}/ssp-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

* Replace the annotation with a label
* Avoid merging bundles togther when using yq
* Remove unnecessary exports of env variables

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
