### PR TITLE
github: Avoid duplicating version annotation step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,14 +44,8 @@ jobs:
           git checkout origin/master -b update-common-instancetypes-${VERSION}
 
           # Update the new common-instancetypes file
-          cp ../common-clusterinstancetypes-bundle.yaml data/common-instancetypes-bundle/
-          cp ../common-clusterpreferences-bundle.yaml data/common-instancetypes-bundle/
-
-          # Install yq and use it to update each resource with an instancetype.kubevirt.io/common-instancetypes-version annotation
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ./yq && chmod +X ./yq
-          for bundle in $(ls data/common-instancetypes-bundle/*.yaml); do
-            yq -i '.metadata.labels.["instancetype.kubevirt.io/common-instancetypes-version"]=env(VERSION)' ${bundle}
-          done
+          cp ../common-clusterinstancetypes-bundle-${VERSION}.yaml data/common-instancetypes-bundle/
+          cp ../common-clusterpreferences-bundle-${VERSION}.yaml data/common-instancetypes-bundle/
 
           git add data && git commit -sm "common-instancetypes: Update bundle to version ${VERSION}"
 


### PR DESCRIPTION
The original files are still accessible from the `Build` step, use them during the `Update SSP Operator` step and avoid annotating twice.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
