### PR TITLE
[release-0.3] chore: Pin KubeVirt to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL=/bin/bash
 
 # Run `make schema` when updating this version and commit the created files.
 # TODO(lyarwood) - Host the expanded JSON schema elsewhere under the kubevirt namespace
-export KUBEVIRT_VERSION = main
+export KUBEVIRT_VERSION = v1.0.0
 
 # Use the COMMON_INSTANCETYPES_CRI env variable to control if the following targets are executed within a container.
 # Supported runtimes are docker and podman. By default targets run directly on the host.
@@ -16,10 +16,10 @@ build_image:
 push_image:
 	./scripts/push_image.sh
 
-lint: 
+lint:
 	./scripts/cri.sh  "./scripts/lint.sh"
 
-generate: 
+generate:
 	./scripts/cri.sh  "./scripts/generate.sh"
 
 validate:
@@ -66,7 +66,7 @@ kubevirt-sync:
 kubevirt-functest:
 	./scripts/kubevirt.sh functest
 
-clean: 
+clean:
 	rm -f common*.yaml
 
 .PHONY: all build_image lint generate schema validate readme

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export KUBEVIRT_TAG="${KUBEVIRT_TAG:-v1.0.0-rc.0}"
+export KUBEVIRT_TAG="${KUBEVIRT_TAG:-v1.0.0}"
 
 _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _kubectl="${_base_dir}/_kubevirt/cluster-up/kubectl.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin KubeVirt to v1.0.0.

`pre-commit` also cleaned up some whitespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
