### PR TITLE
Move instancetype.kubevirt.io/{class,version} to labels

### DIFF
--- a/common-clusterinstancetypes-bundle.yaml
+++ b/common-clusterinstancetypes-bundle.yaml
@@ -3,7 +3,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -16,8 +15,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -25,6 +25,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.2xlarge
 spec:
   cpu:
@@ -43,7 +44,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -56,8 +56,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -65,6 +66,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.4xlarge
 spec:
   cpu:
@@ -83,7 +85,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -96,8 +97,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -105,6 +107,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.8xlarge
 spec:
   cpu:
@@ -123,7 +126,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -136,8 +138,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -145,6 +148,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.large
 spec:
   cpu:
@@ -163,7 +167,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -176,8 +179,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -185,6 +189,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.medium
 spec:
   cpu:
@@ -203,7 +208,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -216,8 +220,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -225,6 +230,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.xlarge
 spec:
   cpu:
@@ -243,7 +249,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -254,12 +259,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.2xlarge
 spec:
   cpu:
@@ -274,7 +281,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -285,12 +291,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.4xlarge
 spec:
   cpu:
@@ -305,7 +313,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -316,12 +323,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.8xlarge
 spec:
   cpu:
@@ -336,7 +345,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -347,12 +355,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.xlarge
 spec:
   cpu:
@@ -367,18 +377,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.2xlarge
 spec:
   cpu:
@@ -392,18 +403,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.4xlarge
 spec:
   cpu:
@@ -417,18 +429,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.8xlarge
 spec:
   cpu:
@@ -442,18 +455,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.large
 spec:
   cpu:
@@ -467,18 +481,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.xlarge
 spec:
   cpu:
@@ -492,17 +507,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.2xlarge
 spec:
   cpu:
@@ -515,17 +531,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.4xlarge
 spec:
   cpu:
@@ -538,17 +555,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.8xlarge
 spec:
   cpu:
@@ -561,17 +579,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.large
 spec:
   cpu:
@@ -584,17 +603,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.medium
 spec:
   cpu:
@@ -607,17 +627,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.xlarge
 spec:
   cpu:
@@ -630,7 +651,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -640,11 +660,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.2xlarge
 spec:
   cpu:
@@ -656,7 +678,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -666,11 +687,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.4xlarge
 spec:
   cpu:
@@ -682,7 +705,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -692,11 +714,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.8xlarge
 spec:
   cpu:
@@ -708,7 +732,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -718,11 +741,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.large
 spec:
   cpu:
@@ -734,7 +759,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -744,11 +768,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.medium
 spec:
   cpu:
@@ -760,7 +786,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -770,11 +795,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.micro
 spec:
   cpu:
@@ -786,7 +813,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -796,11 +822,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.nano
 spec:
   cpu:
@@ -812,7 +840,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -822,11 +849,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.small
 spec:
   cpu:
@@ -838,7 +867,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -848,11 +876,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.xlarge
 spec:
   cpu:

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -3,7 +3,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -16,8 +15,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -25,6 +25,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.2xlarge
 spec:
   cpu:
@@ -43,7 +44,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -56,8 +56,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -65,6 +66,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.4xlarge
 spec:
   cpu:
@@ -83,7 +85,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -96,8 +97,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -105,6 +107,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.8xlarge
 spec:
   cpu:
@@ -123,7 +126,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -136,8 +138,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -145,6 +148,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.large
 spec:
   cpu:
@@ -163,7 +167,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -176,8 +179,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -185,6 +189,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.medium
 spec:
   cpu:
@@ -203,7 +208,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -216,8 +220,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -225,6 +230,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.xlarge
 spec:
   cpu:
@@ -243,7 +249,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -254,12 +259,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.2xlarge
 spec:
   cpu:
@@ -274,7 +281,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -285,12 +291,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.4xlarge
 spec:
   cpu:
@@ -305,7 +313,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -316,12 +323,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.8xlarge
 spec:
   cpu:
@@ -336,7 +345,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -347,12 +355,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.xlarge
 spec:
   cpu:
@@ -367,18 +377,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.2xlarge
 spec:
   cpu:
@@ -392,18 +403,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.4xlarge
 spec:
   cpu:
@@ -417,18 +429,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.8xlarge
 spec:
   cpu:
@@ -442,18 +455,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.large
 spec:
   cpu:
@@ -467,18 +481,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.xlarge
 spec:
   cpu:
@@ -492,17 +507,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.2xlarge
 spec:
   cpu:
@@ -515,17 +531,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.4xlarge
 spec:
   cpu:
@@ -538,17 +555,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.8xlarge
 spec:
   cpu:
@@ -561,17 +579,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.large
 spec:
   cpu:
@@ -584,17 +603,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.medium
 spec:
   cpu:
@@ -607,17 +627,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.xlarge
 spec:
   cpu:
@@ -630,7 +651,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -640,11 +660,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.2xlarge
 spec:
   cpu:
@@ -656,7 +678,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -666,11 +687,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.4xlarge
 spec:
   cpu:
@@ -682,7 +705,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -692,11 +714,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.8xlarge
 spec:
   cpu:
@@ -708,7 +732,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -718,11 +741,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.large
 spec:
   cpu:
@@ -734,7 +759,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -744,11 +768,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.medium
 spec:
   cpu:
@@ -760,7 +786,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -770,11 +795,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.micro
 spec:
   cpu:
@@ -786,7 +813,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -796,11 +822,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.nano
 spec:
   cpu:
@@ -812,7 +840,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -822,11 +849,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.small
 spec:
   cpu:
@@ -838,7 +867,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -848,11 +876,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.xlarge
 spec:
   cpu:
@@ -1998,7 +2028,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2011,8 +2040,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2020,6 +2050,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.2xlarge
 spec:
   cpu:
@@ -2038,7 +2069,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2051,8 +2081,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2060,6 +2091,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.4xlarge
 spec:
   cpu:
@@ -2078,7 +2110,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2091,8 +2122,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2100,6 +2132,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.8xlarge
 spec:
   cpu:
@@ -2118,7 +2151,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2131,8 +2163,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2140,6 +2173,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.large
 spec:
   cpu:
@@ -2158,7 +2192,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2171,8 +2204,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2180,6 +2214,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.medium
 spec:
   cpu:
@@ -2198,7 +2233,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -2211,8 +2245,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -2220,6 +2255,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.xlarge
 spec:
   cpu:
@@ -2238,7 +2274,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -2249,12 +2284,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.2xlarge
 spec:
   cpu:
@@ -2269,7 +2306,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -2280,12 +2316,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.4xlarge
 spec:
   cpu:
@@ -2300,7 +2338,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -2311,12 +2348,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.8xlarge
 spec:
   cpu:
@@ -2331,7 +2370,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -2342,12 +2380,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.xlarge
 spec:
   cpu:
@@ -2362,18 +2402,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.2xlarge
 spec:
   cpu:
@@ -2387,18 +2428,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.4xlarge
 spec:
   cpu:
@@ -2412,18 +2454,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.8xlarge
 spec:
   cpu:
@@ -2437,18 +2480,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.large
 spec:
   cpu:
@@ -2462,18 +2506,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.xlarge
 spec:
   cpu:
@@ -2487,17 +2532,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.2xlarge
 spec:
   cpu:
@@ -2510,17 +2556,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.4xlarge
 spec:
   cpu:
@@ -2533,17 +2580,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.8xlarge
 spec:
   cpu:
@@ -2556,17 +2604,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.large
 spec:
   cpu:
@@ -2579,17 +2628,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.medium
 spec:
   cpu:
@@ -2602,17 +2652,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.xlarge
 spec:
   cpu:
@@ -2625,7 +2676,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2635,11 +2685,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.2xlarge
 spec:
   cpu:
@@ -2651,7 +2703,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2661,11 +2712,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.4xlarge
 spec:
   cpu:
@@ -2677,7 +2730,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2687,11 +2739,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.8xlarge
 spec:
   cpu:
@@ -2703,7 +2757,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2713,11 +2766,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.large
 spec:
   cpu:
@@ -2729,7 +2784,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2739,11 +2793,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.medium
 spec:
   cpu:
@@ -2755,7 +2811,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2765,11 +2820,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.micro
 spec:
   cpu:
@@ -2781,7 +2838,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2791,11 +2847,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.nano
 spec:
   cpu:
@@ -2807,7 +2865,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2817,11 +2874,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.small
 spec:
   cpu:
@@ -2833,7 +2892,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -2843,11 +2901,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.xlarge
 spec:
   cpu:

--- a/common-instancetypes-bundle.yaml
+++ b/common-instancetypes-bundle.yaml
@@ -3,7 +3,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -16,8 +15,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -25,6 +25,7 @@ metadata:
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.2xlarge
 spec:
   cpu:
@@ -43,7 +44,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -56,8 +56,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -65,6 +66,7 @@ metadata:
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.4xlarge
 spec:
   cpu:
@@ -83,7 +85,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -96,8 +97,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -105,6 +107,7 @@ metadata:
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.8xlarge
 spec:
   cpu:
@@ -123,7 +126,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -136,8 +138,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -145,6 +148,7 @@ metadata:
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.large
 spec:
   cpu:
@@ -163,7 +167,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -176,8 +179,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -185,6 +189,7 @@ metadata:
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.medium
 spec:
   cpu:
@@ -203,7 +208,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Compute Exclusive
     instancetype.kubevirt.io/description: |-
       The CX Series provides exclusive compute resources for compute
       intensive applications.
@@ -216,8 +220,9 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Compute Exclusive
   labels:
+    instancetype.kubevirt.io/class: compute.exclusive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/hugepages: "true"
@@ -225,6 +230,7 @@ metadata:
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: cx1.xlarge
 spec:
   cpu:
@@ -243,7 +249,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -254,12 +259,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.2xlarge
 spec:
   cpu:
@@ -274,7 +281,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -285,12 +291,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.4xlarge
 spec:
   cpu:
@@ -305,7 +313,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -316,12 +323,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.8xlarge
 spec:
   cpu:
@@ -336,7 +345,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: GPU NVIDIA
     instancetype.kubevirt.io/description: |-
       The GN Series provides instances types intended for VMs with
       NVIDIA GPU resources attached.
@@ -347,12 +355,14 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: GPU NVIDIA
   labels:
+    instancetype.kubevirt.io/class: gpu.nvidia
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/gpus: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: gn1.xlarge
 spec:
   cpu:
@@ -367,18 +377,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.2xlarge
 spec:
   cpu:
@@ -392,18 +403,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.4xlarge
 spec:
   cpu:
@@ -417,18 +429,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 256Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.8xlarge
 spec:
   cpu:
@@ -442,18 +455,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.large
 spec:
   cpu:
@@ -467,18 +481,19 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Memory Intensive
     instancetype.kubevirt.io/description: |-
       The M Series provides resources for memory intensive
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Memory Intensive
   labels:
+    instancetype.kubevirt.io/class: memory.intensive
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/hugepages: "true"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: m1.xlarge
 spec:
   cpu:
@@ -492,17 +507,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.2xlarge
 spec:
   cpu:
@@ -515,17 +531,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.4xlarge
 spec:
   cpu:
@@ -538,17 +555,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.8xlarge
 spec:
   cpu:
@@ -561,17 +579,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.large
 spec:
   cpu:
@@ -584,17 +603,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.medium
 spec:
   cpu:
@@ -607,17 +627,18 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: Overcommitted
     instancetype.kubevirt.io/description: |-
       The O Series is based on the U Series, with the only difference
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: Overcommitted
   labels:
+    instancetype.kubevirt.io/class: overcommitted
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: o1.xlarge
 spec:
   cpu:
@@ -630,7 +651,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -640,11 +660,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: 32Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.2xlarge
 spec:
   cpu:
@@ -656,7 +678,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -666,11 +687,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: 64Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.4xlarge
 spec:
   cpu:
@@ -682,7 +705,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -692,11 +714,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: 128Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.8xlarge
 spec:
   cpu:
@@ -708,7 +732,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -718,11 +741,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: 8Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.large
 spec:
   cpu:
@@ -734,7 +759,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -744,11 +768,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 4Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.medium
 spec:
   cpu:
@@ -760,7 +786,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -770,11 +795,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 1Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.micro
 spec:
   cpu:
@@ -786,7 +813,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -796,11 +822,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 512Mi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.nano
 spec:
   cpu:
@@ -812,7 +840,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -822,11 +849,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: 2Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.small
 spec:
   cpu:
@@ -838,7 +867,6 @@ apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineInstancetype
 metadata:
   annotations:
-    instancetype.kubevirt.io/class: General Purpose
     instancetype.kubevirt.io/description: |-
       The U Series is quite neutral and provides resources for
       general purpose applications.
@@ -848,11 +876,13 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: General Purpose
   labels:
+    instancetype.kubevirt.io/class: general.purpose
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: 16Gi
     instancetype.kubevirt.io/vendor: kubevirt.io
+    instancetype.kubevirt.io/version: "1"
   name: u1.xlarge
 spec:
   cpu:

--- a/instancetypes/cx/1/cx1.yaml
+++ b/instancetypes/cx/1/cx1.yaml
@@ -15,9 +15,10 @@ metadata:
       the IO threading from cores dedicated to the workload.
       In addition, in this series, the NUMA topology of the used
       cores is provided to the VM.
-    instancetype.kubevirt.io/class: "Compute Exclusive"
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: "Compute Exclusive"
   labels:
+    instancetype.kubevirt.io/class: "compute.exclusive"
+    instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/isolateEmulatorThread: "true"

--- a/instancetypes/gn/1/gn1.yaml
+++ b/instancetypes/gn/1/gn1.yaml
@@ -13,9 +13,10 @@ metadata:
       provided by the
       [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator)
       which is made available on OpenShift via OperatorHub.
-    instancetype.kubevirt.io/class: "GPU NVIDIA"
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: "GPU NVIDIA"
   labels:
+    instancetype.kubevirt.io/class: "gpu.nvidia"
+    instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/gpus: "true"
 spec:

--- a/instancetypes/m/1/m1.yaml
+++ b/instancetypes/m/1/m1.yaml
@@ -8,9 +8,10 @@ metadata:
       applications.
 
       *M* is the abbreviation of "Memory".
-    instancetype.kubevirt.io/class: "Memory Intensive"
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: "Memory Intensive"
   labels:
+    instancetype.kubevirt.io/class: "memory.intensive"
+    instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/hugepages: "true"
 spec:

--- a/instancetypes/o/1/o1.yaml
+++ b/instancetypes/o/1/o1.yaml
@@ -8,9 +8,10 @@ metadata:
       being that memory is overcommitted.
 
       *O* is the abbreviation for "Overcommitted".
-    instancetype.kubevirt.io/class: "Overcommitted"
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: "Overcommitted"
   labels:
+    instancetype.kubevirt.io/class: "overcommitted"
+    instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
 spec:
   memory:

--- a/instancetypes/u/1/u1.yaml
+++ b/instancetypes/u/1/u1.yaml
@@ -12,7 +12,8 @@ metadata:
 
       VMs of instance types will share physical CPU cores on a
       time-slice basis with other VMs.
-    instancetype.kubevirt.io/class: "General Purpose"
-    instancetype.kubevirt.io/version: "1"
+    instancetype.kubevirt.io/displayName: "General Purpose"
   labels:
+    instancetype.kubevirt.io/class: "general.purpose"
+    instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"


### PR DESCRIPTION
**What this PR does / why we need it**:

This should make instance types of a given class and version more discoverable by end users. Given the limitations around labels a new annotation is introduced to store the display name of a given class.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #75

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`instancetype.kubevirt.io/{class,version}' are now labels. A new `instancetype.kubevirt.io/displayName` annotation has been introduced containing the full displayable name of an instance type class.
```
