### PR TITLE
functests: Wait for VMs to become Ready

### DIFF
--- a/scripts/functest.sh
+++ b/scripts/functest.sh
@@ -40,6 +40,13 @@ for preference in $(${KUBECTL} get virtualmachineclusterpreferences --no-headers
         echo "functest failed on preference ${preference} using instancetype u1.medium"
         exit 1
     fi
+
+    if ! ${KUBECTL} wait --for=condition=Ready vms/"vm-${preference}" ; then
+        echo "functest failed to wait for VirtualMachine to become Ready"
+        ${KUBECTL} get vms/"vm-${preference}" -o yaml
+        exit 1
+    fi
+
     ${KUBECTL} delete "vm/vm-${preference}"
 done
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`virtctl create vm` defaults `RunStrategy` to `Always` so we can include a simple check to ensure the VM moves to `Ready` as part of our functests.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
