### PR TITLE
preferences: Deprecate Windows 2k12 preferences

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -680,6 +680,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -737,6 +738,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1643,6 +1643,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -1700,6 +1701,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio
@@ -3740,6 +3742,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -3797,6 +3800,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -680,6 +680,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12
@@ -737,6 +738,7 @@ metadata:
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
     tags: hidden,kubevirt,windows
   labels:
+    instancetype.kubevirt.io/deprecated: "true"
     instancetype.kubevirt.io/os-type: windows
     instancetype.kubevirt.io/vendor: kubevirt.io
   name: windows.2k12.virtio

--- a/preferences/components/deprecated/deprecated.yaml
+++ b/preferences/components/deprecated/deprecated.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: VirtualMachinePreference
+  labels:
+    instancetype.kubevirt.io/deprecated: "true"

--- a/preferences/components/deprecated/kustomization.yaml
+++ b/preferences/components/deprecated/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: deprecated.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: deprecated.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/2k12/kustomization.yaml
+++ b/preferences/windows/2k12/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../base
 
 components:
+  - ../../components/deprecated
   - ./metadata
   - ./requirements
 

--- a/preferences/windows/2k12_virtio/kustomization.yaml
+++ b/preferences/windows/2k12_virtio/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../2k12
 
 components:
+  - ../../components/deprecated
   - ./metadata
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows Server 2k12 goes EOL on October 10th [1], after which support is only available for EUS customers. This change starts the deprecation cycle for our 2k12 preferences ahead of their removal in a future release of the project.

[1] https://learn.microsoft.com/en-us/lifecycle/announcements/windows-server-2012-r2-end-of-support

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Windows Server 2012 preferences have been deprecated ahead of the EOL of the underlying OS later this year.
```
