### PR TITLE
centos.stream9: Remove EFI and secureboot support

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -145,11 +145,6 @@ spec:
     preferredDiskDedicatedIoThread: true
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1
@@ -179,11 +174,6 @@ spec:
     preferredInputType: tablet
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1108,11 +1108,6 @@ spec:
     preferredDiskDedicatedIoThread: true
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1
@@ -1142,11 +1137,6 @@ spec:
     preferredInputType: tablet
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1
@@ -3207,11 +3197,6 @@ spec:
     preferredDiskDedicatedIoThread: true
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1
@@ -3241,11 +3226,6 @@ spec:
     preferredInputType: tablet
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -145,11 +145,6 @@ spec:
     preferredDiskDedicatedIoThread: true
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1
@@ -179,11 +174,6 @@ spec:
     preferredInputType: tablet
     preferredInterfaceModel: virtio
     preferredRng: {}
-  features:
-    preferredSmm: {}
-  firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
   requirements:
     cpu:
       guest: 1

--- a/preferences/centos/9_stream/kustomization.yaml
+++ b/preferences/centos/9_stream/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ./metadata
   - ./requirements
   - ../../components/rng
-  - ../../components/secureboot
   - ../../components/disk-dedicatediothread
 
 nameSuffix: ".stream9"


### PR DESCRIPTION
**What this PR does / why we need it**:

The current cloud images do not support UEFI boot so for now the perferences to enable EFI and secureboot are being removed from the centos.stream9 preference to avoid confusion.

```
$ virt-filesystems -a CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2 --all --long --uuid -h
Name      Type       VFS Label MBR Size Parent   UUID
/dev/sda1 filesystem xfs -     -   7.8G -        a2e35d7f-1574-4fc3-aebd-5e60991d3841
/dev/sda1 partition  -   -     83  7.8G /dev/sda -
/dev/sda  device     -   -     -   10G  -        -
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #101

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
EFI and secureboot are no longer enabled by the `centos-stream9` preference until the CentOS Stream 9 cloud images support UEFI boot
```
