### PR TITLE
release: Add sha256sum `CHECKSUMS.sha256` file to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
           wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O ./yq && chmod +X ./yq
           for bundle in $(ls *bundle-${VERSION}.yaml); do
             yq -i '.metadata.labels.["instancetype.kubevirt.io/common-instancetypes-version"]=env(VERSION)' ${bundle}
+            sha256sum ${bundle} >> CHECKSUMS.sha256
           done
       - name: Release
         id: release
@@ -29,6 +30,7 @@ jobs:
           files: |
             *bundle-${{ github.ref_name }}.yaml
             LICENSE
+            CHECKSUMS.sha256
       - name: Update SSP Operator
         run: |
           # Define vars


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a simple `CHECKSUMS.sha256` file to each release containing `sha256sum` checksums for the released bundles.

See an example release below on my personal repo:

https://github.com/lyarwood/common-instancetypes/releases/tag/v1.3.5

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`sha256sum` checksums are now provided for each release by a `CHECKSUMS.sha256` file
```
