### PR TITLE
Fix Windows 11 minimum CPU requirement

### DIFF
--- a/preferences/windows/11/requirements/requirements.yaml
+++ b/preferences/windows/11/requirements/requirements.yaml
@@ -7,6 +7,6 @@ spec:
   # https://www.microsoft.com/en-gb/windows/windows-11-specifications?r=1
   requirements:
     cpu:
-      guest: 1
+      guest: 2
     memory:
       guest: 4Gi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Set the minimum required CPUs to two as mandated by the Windows 11 System Requirements.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #109 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set Windows 11 minimum CPU requirement to two
```
