### PR TITLE
[release-0.3] preferences: Adjust display-name of windows virtio

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -548,7 +548,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11
+    openshift.io/display-name: Microsoft Windows 11 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -886,7 +886,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019
+    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1530,7 +1530,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11
+    openshift.io/display-name: Microsoft Windows 11 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -1868,7 +1868,7 @@ kind: VirtualMachineClusterPreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019
+    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -3636,7 +3636,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11
+    openshift.io/display-name: Microsoft Windows 11 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -3974,7 +3974,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019
+    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues

--- a/common-instancetypes/preferences/windows/11/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/11/metadata/metadata.yaml
@@ -4,4 +4,4 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Microsoft Windows 11"
+    openshift.io/display-name: "Microsoft Windows 11 (virtio)"

--- a/common-instancetypes/preferences/windows/2k19/metadata/metadata.yaml
+++ b/common-instancetypes/preferences/windows/2k19/metadata/metadata.yaml
@@ -4,4 +4,4 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Microsoft Windows Server 2019"
+    openshift.io/display-name: "Microsoft Windows Server 2019 (virtio)"

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -548,7 +548,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows 11
+    openshift.io/display-name: Microsoft Windows 11 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues
@@ -886,7 +886,7 @@ kind: VirtualMachinePreference
 metadata:
   annotations:
     iconClass: icon-windows
-    openshift.io/display-name: Microsoft Windows Server 2019
+    openshift.io/display-name: Microsoft Windows Server 2019 (virtio)
     openshift.io/documentation-url: https://github.com/kubevirt/common-instancetypes
     openshift.io/provider-display-name: KubeVirt
     openshift.io/support-url: https://github.com/kubevirt/common-instancetypes/issues


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The display name "Microsoft Windows 11 (virtio)" and "Microsoft Windows Server 2019 (virtio)" containing the "virtio" is more consistent.

Manualy cherry-pick of a5991ebc5cfc8814c783463dfab07543ba8b74df that is necessary due to ordering changes in the generated bundle files.

CONFLICTS:
  common-clusterpreferences-bundle.yaml
  common-instancetypes-all-bundle.yaml
  common-preferences-bundle.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adjust display-name of windows.11.virtio and windows.2k19.virtio
```
