### PR TITLE
fix: Add missing requirements to windows.11 preferences

### DIFF
--- a/preferences/windows/11/kustomization.yaml
+++ b/preferences/windows/11/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 components:
   - ./metadata
+  - ./requirements
   - ../../components/tpm
   - ../../components/secureboot
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add missing requirements to windows.11 preferences

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Add missing requirements to windows.11 preferences
```
