### PR TITLE
[release-0.3] fix: Add missing requirements to windows.11 and windows.2k16 preferences

### DIFF
--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -599,6 +599,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -658,6 +663,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference

--- a/common-clusterpreferences-bundle.yaml
+++ b/common-clusterpreferences-bundle.yaml
@@ -836,6 +836,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -890,6 +895,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1581,6 +1581,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -1640,6 +1645,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -3687,6 +3697,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
@@ -3746,6 +3761,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference

--- a/common-instancetypes-all-bundle.yaml
+++ b/common-instancetypes-all-bundle.yaml
@@ -1818,6 +1818,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -1872,6 +1877,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterPreference
@@ -3934,6 +3944,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
@@ -3988,6 +4003,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference

--- a/common-instancetypes/preferences/windows/11/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/11/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
 
 components:
   - ./metadata
+  - ./requirements
   - ../../components/tpm
   - ../../components/secureboot

--- a/common-instancetypes/preferences/windows/2k16/kustomization.yaml
+++ b/common-instancetypes/preferences/windows/2k16/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 
 components:
   - ./metadata
+  - ./requirements
 
 nameSuffix: .2k16

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -599,6 +599,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
@@ -658,6 +663,11 @@ spec:
     preferredUseEfi: true
     preferredUseSecureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 4Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference

--- a/common-preferences-bundle.yaml
+++ b/common-preferences-bundle.yaml
@@ -836,6 +836,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference
@@ -890,6 +895,11 @@ spec:
       vapic: {}
       vpindex: {}
   preferredTerminationGracePeriodSeconds: 3600
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachinePreference

--- a/scripts/functest.sh
+++ b/scripts/functest.sh
@@ -35,9 +35,9 @@ for preference in $(${KUBECTL} get virtualmachineclusterpreferences --no-headers
         fi
     fi
 
-    # Ensure a VirtualMachine can be created when enough resources are provided using the u1.medium instance type
-    if ! ${VIRTCTL} create vm --instancetype u1.medium --preference "${preference}" --volume-containerdisk name:disk,src:quay.io/containerdisks/fedora:latest --name "vm-${preference}" | ${KUBECTL} apply -f - ; then
-        echo "functest failed on preference ${preference} using instancetype u1.medium"
+    # Ensure a VirtualMachine can be created when enough resources are provided using the u1.large instance type
+    if ! ${VIRTCTL} create vm --instancetype u1.large --preference "${preference}" --volume-containerdisk name:disk,src:quay.io/containerdisks/fedora:latest --name "vm-${preference}" | ${KUBECTL} apply -f - ; then
+        echo "functest failed on preference ${preference} using instancetype u1.large"
         exit 1
     fi
     ${KUBECTL} delete "vm/vm-${preference}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add missing requirements to windows.11 and windows.2k16 preferences and move functests to u1.large instancetype.

Manualy cherry-pick of 16096fb1e1507142ebd74d2801e3bc24884e563 and f39e6c5993f1565334c2046f95019875b035b584.

CONFLICTS:
  - common-clusterpreferences-bundle.yaml
  - common-instancetypes-all-bundle.yaml
  - common-preferences-bundle.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Add missing requirements to windows.11 preferences
fix: Add missing requirements to windows.2k16 preferences
```
