### PR TITLE
fix: Move functests to u1.large instancetypes

### DIFF
--- a/scripts/functest.sh
+++ b/scripts/functest.sh
@@ -47,9 +47,9 @@ for preference in $(${KUBECTL} get virtualmachineclusterpreferences --no-headers
         fi
     fi
 
-    # Ensure a VirtualMachine can be created when enough resources are provided using the u1.medium instance type
-    if ! ${VIRTCTL} create vm --instancetype u1.medium --preference "${preference}" --volume-containerdisk name:disk,src:quay.io/containerdisks/fedora:latest --name "vm-${preference}" | ${KUBECTL} apply -f - ; then
-        echo "functest failed on preference ${preference} using instancetype u1.medium"
+    # Ensure a VirtualMachine can be created when enough resources are provided using the u1.large instance type
+    if ! ${VIRTCTL} create vm --instancetype u1.large --preference "${preference}" --volume-containerdisk name:disk,src:quay.io/containerdisks/fedora:latest --name "vm-${preference}" | ${KUBECTL} apply -f - ; then
+        echo "functest failed on preference ${preference} using instancetype u1.large"
         exit 1
     fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After fixing the missing requirements on windows.11 preferences, they now need at least 2 vCPUs to pass the functional tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
