### PR TITLE
fix: Remove incorrect numa label from N instance types

### DIFF
--- a/instancetypes/n/1/n1.yaml
+++ b/instancetypes/n/1/n1.yaml
@@ -19,7 +19,6 @@ metadata:
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/hugepages: "true"
 spec:
   annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove the incorrect numa label from N instance types.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
