### PR TITLE
chore: Randomize functests and be more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ cluster-sync: kustomize
 
 .PHONY: cluster-functest
 cluster-functest:
-	cd tests && KUBECONFIG=$$(../scripts/kubevirtci.sh kubeconfig) go test -v -timeout 0 ./functests/... $(FUNCTEST_EXTRA_ARGS)
+	cd tests && KUBECONFIG=$$(../scripts/kubevirtci.sh kubeconfig) go test -v -timeout 0 ./functests/... -ginkgo.v -ginkgo.randomize-all $(FUNCTEST_EXTRA_ARGS)
 
 .PHONY: kubevirt-up
 kubevirt-up:
@@ -83,7 +83,7 @@ kubevirt-sync: kustomize
 
 .PHONY: kubevirt-functest
 kubevirt-functest:
-	cd tests && KUBECONFIG=$$(../scripts/kubevirt.sh kubeconfig) go test -v -timeout 0 ./functests/... $(FUNCTEST_EXTRA_ARGS)
+	cd tests && KUBECONFIG=$$(../scripts/kubevirt.sh kubeconfig) go test -v -timeout 0 ./functests/... -ginkgo.v -ginkgo.randomize-all $(FUNCTEST_EXTRA_ARGS)
 
 .PHONY: test
 test: generate


### PR DESCRIPTION
**What this PR does / why we need it**:

Randomize the order of functests on each run and be more verbose during running the tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
