### PR TITLE
fix: Pull containerdisks before pushing them

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -49,6 +49,7 @@ function kubevirt::sync() {
 }
 
 function kubevirt::sync-containerdisks() {
+  podman pull "${VALIDATION_OS_IMAGE}:${VALIDATION_OS_IMAGE_TAG}"
   podman push --tls-verify=false \
     "${VALIDATION_OS_IMAGE}:${VALIDATION_OS_IMAGE_TAG}" \
     "$(kubevirt::registry)/validation-os-container-disk:latest"

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -71,6 +71,7 @@ function kubevirtci::sync() {
 }
 
 function kubevirtci::sync-containerdisks() {
+  podman pull "${VALIDATION_OS_IMAGE}:${VALIDATION_OS_IMAGE_TAG}"
   podman push --tls-verify=false \
     "${VALIDATION_OS_IMAGE}:${VALIDATION_OS_IMAGE_TAG}" \
     "$(kubevirtci::registry)/validation-os-container-disk:latest"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Containerdisks need to be pulled to the local image store before they can be pushed to another remote.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
