### PR TITLE
chore: Fix KubeVirt and kubevirtci versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL=/bin/bash
 
 # Run `make schema` when updating this version and commit the created files.
 # TODO(lyarwood) - Host the expanded JSON schema elsewhere under the kubevirt namespace
-export KUBEVIRT_VERSION = main
+export KUBEVIRT_VERSION = v1.1.0
+export KUBEVIRTCI_TAG = 2310161449-94f7214
 
 # Use the COMMON_INSTANCETYPES_CRI env variable to control if the following targets are executed within a container.
 # Supported runtimes are docker and podman. By default targets run directly on the host.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Fix the version of KubeVirt to v1.1.0 and the version of kubevirtci to 2310161449-94f7214.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
