### PR TITLE
fix: Replace names in checksum file during release

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -11,6 +11,8 @@ fi
 COMMON_INSTANCETYPES_VERSION=${COMMON_INSTANCETYPES_VERSION} make
 
 cd _build || exit 1
-for f in common-*-bundle.yaml; do
-    cp "${f}" "${f/\.yaml/-${COMMON_INSTANCETYPES_VERSION}\.yaml}"
+for file in common-*-bundle.yaml; do
+    file_versioned=${file/\.yaml/-${COMMON_INSTANCETYPES_VERSION}\.yaml}
+    mv "${file}" "${file_versioned}"
+    sed -i "s/${file}/${file_versioned}/g" CHECKSUMS.sha256
 done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Set the correct filenames in CHECKSUMS.sha256 during a release so the
checksum file uses the versioned filenames instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
