### PR TITLE
Update Windows 10 preference to allow for boot from UEFI with TPM

### DIFF
--- a/preferences/windows/10/kustomization.yaml
+++ b/preferences/windows/10/kustomization.yaml
@@ -8,5 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/tpm
+  - ../../components/secureboot
 
 nameSuffix: ".10"


### PR DESCRIPTION
This is to keep the Windows 10 preference consistent with the Windows 10 template in [common-templates](https://github.com/kubevirt/common-templates/pull/559), also aligning with Windows 2k22 and Windows 11 which also use UEFI with TPM.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: UEFI and TPM enables additional functionalities in Windows

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows 10 preference now boots from UEFI with TPM instead of BIOS
```
