### PR TITLE
Add Windows functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _kubevirt/
 _schemas/
 common-*-bundle.yaml
 CHECKSUMS.sha256
+*.qcow2

--- a/image/build_windows_containerdisk.sh
+++ b/image/build_windows_containerdisk.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "Please pass Windows image version to build as first argument."
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Please pass path to Windows ISO as second argument."
+  exit 1
+fi
+
+WINDOWS_VERSION=$1
+WINDOWS_ISO=$2
+
+# Default vars
+WINDOWS_ISO_EXTRACT_PATH=/tmp/${WINDOWS_VERSION}
+WINDOWS_ISO_MODIFIED=/tmp/${WINDOWS_VERSION}.iso
+VIRTIO_WIN_ISO_LATEST_URL=https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso
+VIRTIO_WIN_ISO=/tmp/virtio-win.iso
+# EFI boot by default
+WINDOWS_BOOT_IMAGE=(-e efi/microsoft/boot/efisys_noprompt.bin)
+
+case "$WINDOWS_VERSION" in
+  windows10)
+    OS_VARIANT=win10
+    WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows10)
+    VIRT_INSTALL_EXTRA_ARGS=(--boot uefi)
+    ;;
+  windows11)
+    OS_VARIANT=win11
+    WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows11)
+    ;;
+  windows2k16)
+    OS_VARIANT=win2k16
+    WINDOWS_ISO_OVERLAYS=(overlays/windows2k16)
+    # Create BIOS bootable ISO
+    WINDOWS_BOOT_IMAGE=(-b boot/etfsboot.com)
+    ;;
+  windows2k19)
+    OS_VARIANT=win2k19
+    WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows2k19)
+    # Create BIOS bootable ISO
+    WINDOWS_BOOT_IMAGE=(-b boot/etfsboot.com)
+    ;;
+  windows2k22)
+    OS_VARIANT=win2k22
+    WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows2k22)
+    VIRT_INSTALL_EXTRA_ARGS=(--boot uefi)
+    ;;
+  *)
+    echo "Need a valid Windows image version to build: windows10, windows11, windows2k16, windows2k19, windows2k22"
+    exit 1
+    ;;
+esac
+
+# Extract Windows ISO, create a bootable ISO with overlays applied that does not prompt for a key and clean up
+# By default the ISO is EFI bootable
+7z x "${WINDOWS_ISO}" -o"${WINDOWS_ISO_EXTRACT_PATH}"
+mkisofs -udf --allow-limited-size "${WINDOWS_BOOT_IMAGE[@]}" -no-emul-boot \
+  -o "${WINDOWS_ISO_MODIFIED}" "${WINDOWS_ISO_EXTRACT_PATH}" "${WINDOWS_ISO_OVERLAYS[@]}"
+rm -r "${WINDOWS_ISO_EXTRACT_PATH}"
+
+# Download latest virtio-win.iso if it was not passed as argument, else copy passed ISO to /tmp
+if [ -z "$3" ]; then
+  curl -L "${VIRTIO_WIN_ISO_LATEST_URL}" -o "${VIRTIO_WIN_ISO}"
+else
+  cp "$3" "${VIRTIO_WIN_ISO}"
+fi
+
+# Set required SELinux contexts
+chcon -t virt_content_t "${WINDOWS_ISO_MODIFIED}"
+chcon -t virt_content_t "${VIRTIO_WIN_ISO}"
+
+# Start installation process and wait for first reboot of VM, then restart it
+virt-install --noautoconsole --wait --name="${WINDOWS_VERSION}" \
+  --vcpus=2 --memory=8192 --disk size=15 --video virtio --os-variant="${OS_VARIANT}" \
+  --cdrom="${WINDOWS_ISO_MODIFIED}" --disk device=cdrom,path="${VIRTIO_WIN_ISO}" \
+  "${VIRT_INSTALL_EXTRA_ARGS[@]}"
+
+# Second loop to wait for VM to shut down after finished install
+while LANG=C virsh domstate "${WINDOWS_VERSION}" | grep running > /dev/null; do
+  sleep 1
+done
+
+# Compress VM disk
+qemu-img convert -p -O qcow2 -c "$HOME/.local/share/libvirt/images/${WINDOWS_VERSION}.qcow2" "${WINDOWS_VERSION}.qcow2"
+
+# Remove VM and all images
+virsh undefine --nvram --remove-all-storage "${WINDOWS_VERSION}"
+
+# Build containerdisk
+podman build -t "${WINDOWS_VERSION}-container-disk:latest" -f - . << EOF
+FROM scratch
+ADD --chown=107:107 ${WINDOWS_VERSION}.qcow2 /disk/
+EOF
+
+# Remove VM disk
+rm "${WINDOWS_VERSION}.qcow2"

--- a/image/overlays/generic/post-install.ps1
+++ b/image/overlays/generic/post-install.ps1
@@ -1,0 +1,37 @@
+# Install virtio guest drivers
+Start-Process msiexec -Wait -ArgumentList "/i E:\virtio-win-gt-x64.msi /qn /passive /norestart"
+
+# Install qemu guest agent
+Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+#
+# Taken from https://learn.microsoft.com/de-de/windows-server/administration/openssh/openssh_install_firstuse?tabs=powershell
+#
+
+# Install the OpenSSH Server
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+
+# Start the sshd service
+Start-Service sshd
+
+# OPTIONAL but recommended:
+Set-Service -Name sshd -StartupType 'Automatic'
+
+# Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
+if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
+    Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+} else {
+    Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+}
+
+# Download and run SDelete
+$url = "https://download.sysinternals.com/files/SDelete.zip"
+$file = "C:\SDelete.zip"
+$path = "C:\SDelete"
+Invoke-WebRequest -Uri $url -OutFile $file
+Expand-Archive -LiteralPath $file -DestinationPath $path
+Start-Process $path\sdelete64.exe -Wait -ArgumentList "-accepteula -z C:"
+
+# Shut down the machine
+Stop-Computer -Force

--- a/image/overlays/windows10/autounattend.xml
+++ b/image/overlays/windows10/autounattend.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <WillShowUI>Never</WillShowUI>
+        <Disk wcm:action="add">
+          <!-- https://foxpa.ws/win-10-11-unattended -->
+          <!-- https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions?view=windows-11 -->
+          <CreatePartitions>
+              <CreatePartition wcm:action="add">
+                  <Order>1</Order>
+                  <Type>EFI</Type>
+                  <Size>100</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>2</Order>
+                  <Type>MSR</Type>
+                  <Size>16</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>3</Order>
+                  <Type>Primary</Type>
+                  <Extend>true</Extend>
+              </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+                <Order>1</Order>
+                <PartitionID>1</PartitionID>
+                <Label>EFI</Label>
+                <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+                <Order>2</Order>
+                <PartitionID>3</PartitionID>
+                <Label>Windows</Label>
+                <Letter>C</Letter>
+                <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/Image/Description</Key>
+              <Value>Windows 10 Pro</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <ProductKey>
+          <Key/>
+        </ProductKey>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Password>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile D:\post-install.ps1</CommandLine>
+          <Description>Run post-install.ps1 script</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/image/overlays/windows11/autounattend.xml
+++ b/image/overlays/windows11/autounattend.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <WillShowUI>Never</WillShowUI>
+        <Disk wcm:action="add">
+          <!-- https://foxpa.ws/win-10-11-unattended -->
+          <!-- https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions?view=windows-11 -->
+          <CreatePartitions>
+              <CreatePartition wcm:action="add">
+                  <Order>1</Order>
+                  <Type>EFI</Type>
+                  <Size>100</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>2</Order>
+                  <Type>MSR</Type>
+                  <Size>16</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>3</Order>
+                  <Type>Primary</Type>
+                  <Extend>true</Extend>
+              </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+                <Order>1</Order>
+                <PartitionID>1</PartitionID>
+                <Label>EFI</Label>
+                <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+                <Order>2</Order>
+                <PartitionID>3</PartitionID>
+                <Label>Windows</Label>
+                <Letter>C</Letter>
+                <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/Image/Description</Key>
+              <Value>Windows 11 Pro</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <ProductKey>
+          <Key/>
+        </ProductKey>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Password>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile D:\post-install.ps1</CommandLine>
+          <Description>Run post-install.ps1 script</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/image/overlays/windows2k16/autounattend.xml
+++ b/image/overlays/windows2k16/autounattend.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <WillShowUI>Never</WillShowUI>
+        <Disk wcm:action="add">
+          <CreatePartitions>
+            <!-- Windows partition -->
+            <CreatePartition wcm:action="add">
+                <Order>1</Order>
+                <Type>Primary</Type>
+                <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <!-- Windows partition -->
+            <ModifyPartition wcm:action="add">
+                <Order>1</Order>
+                <PartitionID>1</PartitionID>
+                <Label>Windows</Label>
+                <Format>NTFS</Format>
+                <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/Image/Description</Key>
+              <Value>Windows Server 2016 SERVERSTANDARDCORE</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>1</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Password>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile D:\post-install.ps1</CommandLine>
+          <Description>Run post-install.ps1 script</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/image/overlays/windows2k16/post-install.ps1
+++ b/image/overlays/windows2k16/post-install.ps1
@@ -1,0 +1,19 @@
+# Install virtio guest drivers
+Start-Process msiexec -Wait -ArgumentList "/i E:\virtio-win-gt-x64.msi /qn /passive /norestart"
+
+# Install qemu guest agent
+Start-Process msiexec -Wait -ArgumentList "/i E:\guest-agent\qemu-ga-x86_64.msi /qn /passive /norestart"
+
+# Enable Tls12, which is not enabled by default in Windows Server 2016
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Download and run SDelete
+$url = "https://download.sysinternals.com/files/SDelete.zip"
+$file = "C:\SDelete.zip"
+$path = "C:\SDelete"
+Invoke-WebRequest -Uri $url -OutFile $file
+Expand-Archive -LiteralPath $file -DestinationPath $path
+Start-Process $path\sdelete64.exe -Wait -ArgumentList "-accepteula -z C:"
+
+# Shut down the machine
+Stop-Computer -Force

--- a/image/overlays/windows2k19/autounattend.xml
+++ b/image/overlays/windows2k19/autounattend.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <WillShowUI>Never</WillShowUI>
+        <Disk wcm:action="add">
+          <CreatePartitions>
+            <!-- Windows partition -->
+            <CreatePartition wcm:action="add">
+                <Order>1</Order>
+                <Type>Primary</Type>
+                <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <!-- Windows partition -->
+            <ModifyPartition wcm:action="add">
+                <Order>1</Order>
+                <PartitionID>1</PartitionID>
+                <Label>Windows</Label>
+                <Format>NTFS</Format>
+                <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/Image/Description</Key>
+              <Value>Windows Server 2019 SERVERSTANDARDCORE</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>1</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Password>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile D:\post-install.ps1</CommandLine>
+          <Description>Run post-install.ps1 script</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/image/overlays/windows2k22/autounattend.xml
+++ b/image/overlays/windows2k22/autounattend.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <DiskConfiguration>
+        <WillShowUI>Never</WillShowUI>
+        <Disk wcm:action="add">
+          <!-- https://foxpa.ws/win-10-11-unattended -->
+          <!-- https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions?view=windows-11 -->
+          <CreatePartitions>
+              <CreatePartition wcm:action="add">
+                  <Order>1</Order>
+                  <Type>EFI</Type>
+                  <Size>100</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>2</Order>
+                  <Type>MSR</Type>
+                  <Size>16</Size>
+              </CreatePartition>
+              <CreatePartition wcm:action="add">
+                  <Order>3</Order>
+                  <Type>Primary</Type>
+                  <Extend>true</Extend>
+              </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+                <Order>1</Order>
+                <PartitionID>1</PartitionID>
+                <Label>EFI</Label>
+                <Format>FAT32</Format>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+                <Order>2</Order>
+                <PartitionID>3</PartitionID>
+                <Label>Windows</Label>
+                <Letter>C</Letter>
+                <Format>NTFS</Format>
+            </ModifyPartition>
+          </ModifyPartitions>
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallFrom>
+            <MetaData wcm:action="add">
+              <Key>/Image/Description</Key>
+              <Value>Windows Server 2022 SERVERSTANDARDCORE</Value>
+            </MetaData>
+          </InstallFrom>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+      </UserData>
+    </component>
+  </settings>
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <InputLocale>0409:00000409</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <AdministratorPassword>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Password>
+          <Value>Administrator</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <Username>Administrator</Username>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>PowerShell -ExecutionPolicy Bypass -NoProfile D:\post-install.ps1</CommandLine>
+          <Description>Run post-install.ps1 script</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -30,6 +30,11 @@ const (
 	defaultUbuntu2004ContainerDisk    = "quay.io/containerdisks/ubuntu:20.04"
 	defaultUbuntu2204ContainerDisk    = "quay.io/containerdisks/ubuntu:22.04"
 	defaultValidationOsContainerDisk  = "registry:5000/validation-os-container-disk:latest"
+	defaultWindows10ContainerDisk     = "registry:5000/windows10-container-disk:latest"
+	defaultWindows11ContainerDisk     = "registry:5000/windows11-container-disk:latest"
+	defaultWindows2k16ContainerDisk   = "registry:5000/windows2k16-container-disk:latest"
+	defaultWindows2k19ContainerDisk   = "registry:5000/windows2k19-container-disk:latest"
+	defaultWindows2k22ContainerDisk   = "registry:5000/windows2k22-container-disk:latest"
 )
 
 var (
@@ -44,6 +49,11 @@ var (
 	ubuntu2004ContainerDisk    string
 	ubuntu2204ContainerDisk    string
 	validationOsContainerDisk  string
+	windows10ContainerDisk     string
+	windows11ContainerDisk     string
+	windows2k16ContainerDisk   string
+	windows2k19ContainerDisk   string
+	windows2k22ContainerDisk   string
 )
 
 //nolint:gochecknoinits
@@ -66,6 +76,16 @@ func init() {
 		defaultUbuntu2204ContainerDisk, "Ubuntu 22.04 container disk used by functional tests")
 	flag.StringVar(&validationOsContainerDisk, "validation-os-container-disk",
 		defaultValidationOsContainerDisk, "Validation OS container disk used by functional tests")
+	flag.StringVar(&windows10ContainerDisk, "windows-10-container-disk",
+		defaultWindows10ContainerDisk, "Windows 10 container disk used by functional tests")
+	flag.StringVar(&windows11ContainerDisk, "windows-11-container-disk",
+		defaultWindows11ContainerDisk, "Windows 11 container disk used by functional tests")
+	flag.StringVar(&windows2k16ContainerDisk, "windows-2k16-container-disk",
+		defaultWindows2k16ContainerDisk, "Windows Server 2016 container disk used by functional tests")
+	flag.StringVar(&windows2k19ContainerDisk, "windows-2k19-container-disk",
+		defaultWindows2k19ContainerDisk, "Windows Server 2019 container disk used by functional tests")
+	flag.StringVar(&windows2k22ContainerDisk, "windows-2k22-container-disk",
+		defaultWindows2k22ContainerDisk, "Windows Server 2022 container disk used by functional tests")
 }
 
 func checkDeployedResources() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds the build_windows_containerdisks.sh script, which uses libvirt to run fully automated installations of OSes and packages them as containerdisks. It also adds functional tests for all supported OSes.

The following OSes are supported:

- Windows 10
- Windows 11
- Windows Server 2016
- Windows Server 2019
- Windows Server 2022

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
