### PR TITLE
fix: Remove TPM from Windows 10 preference

### DIFF
--- a/preferences/windows/10/kustomization.yaml
+++ b/preferences/windows/10/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
   - ./metadata
   - ./requirements
-  - ../../components/tpm
   - ../../components/secureboot
 
 nameSuffix: ".10"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Windows 10 does not strictly require a TPM. A TPM without persistence might even lead to data loss, when encryption keys are lost.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Windows 10 preference now boots from UEFI instead of BIOS
```
