### PR TITLE
[release-0.4] tests: Move windows10 image back to BIOS boot

### DIFF
--- a/image/build_windows_containerdisk.sh
+++ b/image/build_windows_containerdisk.sh
@@ -28,7 +28,8 @@ case "$WINDOWS_VERSION" in
   windows10)
     OS_VARIANT=win10
     WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows10)
-    VIRT_INSTALL_EXTRA_ARGS=(--boot uefi)
+    # Create BIOS bootable ISO
+    WINDOWS_BOOT_IMAGE=(-b boot/etfsboot.com)
     DEFAULT_PREFERENCE=windows.10.virtio
     ;;
   windows11)

--- a/image/overlays/windows10/autounattend.xml
+++ b/image/overlays/windows10/autounattend.xml
@@ -21,38 +21,22 @@
       <DiskConfiguration>
         <WillShowUI>Never</WillShowUI>
         <Disk wcm:action="add">
-          <!-- https://foxpa.ws/win-10-11-unattended -->
-          <!-- https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/configure-uefigpt-based-hard-drive-partitions?view=windows-11 -->
           <CreatePartitions>
-              <CreatePartition wcm:action="add">
-                  <Order>1</Order>
-                  <Type>EFI</Type>
-                  <Size>100</Size>
-              </CreatePartition>
-              <CreatePartition wcm:action="add">
-                  <Order>2</Order>
-                  <Type>MSR</Type>
-                  <Size>16</Size>
-              </CreatePartition>
-              <CreatePartition wcm:action="add">
-                  <Order>3</Order>
-                  <Type>Primary</Type>
-                  <Extend>true</Extend>
-              </CreatePartition>
+            <!-- Windows partition -->
+            <CreatePartition wcm:action="add">
+                <Order>1</Order>
+                <Type>Primary</Type>
+                <Extend>true</Extend>
+            </CreatePartition>
           </CreatePartitions>
           <ModifyPartitions>
+            <!-- Windows partition -->
             <ModifyPartition wcm:action="add">
                 <Order>1</Order>
                 <PartitionID>1</PartitionID>
-                <Label>EFI</Label>
-                <Format>FAT32</Format>
-            </ModifyPartition>
-            <ModifyPartition wcm:action="add">
-                <Order>2</Order>
-                <PartitionID>3</PartitionID>
                 <Label>Windows</Label>
-                <Letter>C</Letter>
                 <Format>NTFS</Format>
+                <Letter>C</Letter>
             </ModifyPartition>
           </ModifyPartitions>
           <DiskID>0</DiskID>
@@ -69,7 +53,7 @@
           </InstallFrom>
           <InstallTo>
             <DiskID>0</DiskID>
-            <PartitionID>3</PartitionID>
+            <PartitionID>1</PartitionID>
           </InstallTo>
         </OSImage>
       </ImageInstall>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The windows10 preference in release-0.4 is still using BIOS to boot the VM, so change the test image to reflect that.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
