### PR TITLE
cleanup: Drop labels from images

### DIFF
--- a/image/build_windows_containerdisk.sh
+++ b/image/build_windows_containerdisk.sh
@@ -101,11 +101,6 @@ podman build -t "${WINDOWS_VERSION}-container-disk:latest" -f - . << EOF
 FROM scratch
 ADD --chown=107:107 ${WINDOWS_VERSION}.qcow2 /disk/
 
-LABEL instancetype.kubevirt.io/default-instancetype ${DEFAULT_INSTANCETYPE}
-LABEL instancetype.kubevirt.io/default-preference ${DEFAULT_PREFERENCE}
-LABEL instancetype.kubevirt.io/display-needed true
-
-# Set ENVs for compatibility with crun-vm
 ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE ${DEFAULT_INSTANCETYPE}
 ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE ${DEFAULT_PREFERENCE}
 ENV INSTANCETYPE_KUBEVIRT_IO_DISPLAY_NEEDED true

--- a/image/validationos.Dockerfile
+++ b/image/validationos.Dockerfile
@@ -56,11 +56,6 @@ FROM scratch
 
 COPY --from=builder --chown=107:107 /disk.img /disk/
 
-LABEL instancetype.kubevirt.io/default-instancetype u1.large
-LABEL instancetype.kubevirt.io/default-preference windows.11
-LABEL instancetype.kubevirt.io/display-needed true
-
-# Set ENVs for compatibility with crun-vm
 ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE u1.large
 ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE windows.11
 ENV INSTANCETYPE_KUBEVIRT_IO_DISPLAY_NEEDED true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since ENV variables were chosen as the way forward to decorate images with appropriate default instancetypes and preferences the labels are dropped from images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
