### PR TITLE
Windows 11, 2k22: Enable persistent TPMs

### DIFF
--- a/preferences/components/tpm/tpm.yaml
+++ b/preferences/components/tpm/tpm.yaml
@@ -5,4 +5,5 @@ metadata:
   name: tpm
 spec:
   devices:
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -16,6 +16,9 @@
 
 set -ex
 
+# Required by the VMPersistentState feature that currently needs a RWX FS mode SC
+# https://kubevirt.io/user-guide/virtual_machines/persistent_tpm_and_uefi_state/
+export KUBEVIRT_DEPLOY_NFS_CSI="${KUBEVIRT_DEPLOY_NFS_CSI:-true}"
 export KUBEVIRT_MEMORY_SIZE="${KUBEVIRT_MEMORY_SIZE:-16G}"
 export KUBEVIRT_TAG="${KUBEVIRT_TAG:-main}"
 
@@ -36,8 +39,8 @@ function kubevirt::install() {
 function kubevirt::up() {
   make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
 
-  echo "enabling the GPU and NUMA feature gates to validate instance types"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA"]}}}}'
+  echo "enabling feature gates to validate instance types and preferences"
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 }
 
 function kubevirt::down() {

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -16,6 +16,9 @@
 
 set -ex
 
+# Required by the VMPersistentState feature that currently needs a RWX FS mode SC
+# https://kubevirt.io/user-guide/virtual_machines/persistent_tpm_and_uefi_state/
+export KUBEVIRT_DEPLOY_NFS_CSI="${KUBEVIRT_DEPLOY_NFS_CSI:-true}"
 export KUBEVIRT_MEMORY_SIZE="${KUBEVIRT_MEMORY_SIZE:-16G}"
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)}
 export KUBEVIRT_DEPLOY_CDI="true"
@@ -63,8 +66,8 @@ function kubevirtci::up() {
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 
-  echo "enabling the GPU and NUMA feature gates to validate instance types"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA"]}}}}'
+  echo "enabling feature gates to validate instance types and preferences"
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 }
 
 function kubevirtci::down() {


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #168 

https://issues.redhat.com/browse/CNV-39710

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Persistent TPMs are now provided by the Windows 11 and Windows 2k22 preferences, this requires that the `VMPersistentState` feature gate is enabled and configured correctly.
```
