### PR TITLE
Revert "Windows 11, 2k22: Enable persistent TPMs"

### DIFF
--- a/preferences/components/tpm/tpm.yaml
+++ b/preferences/components/tpm/tpm.yaml
@@ -5,5 +5,4 @@ metadata:
   name: tpm
 spec:
   devices:
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}


### PR DESCRIPTION
/cc @0xFelix 
/cherry-pick release-1.0
/cherry-pick release-0.4

**What this PR does / why we need it**:

This reverts commit b9e4cafd321dfb7a5b14e480e98431098363316c.

After initially being against this [1], being won over by a counter argument [2] and then landing this change [3] it has now come to light that the `common-templates` project will be holding off from switching this on until the underlying feature supports RWO storage classes [4]. In order to stay aligned with `common-templates` this PR reverts the change for the time being.

[1] https://github.com/kubevirt/common-instancetypes/pull/167#issuecomment-2022714965
[2] https://github.com/kubevirt/common-instancetypes/issues/168#issuecomment-2042456495
[3] https://github.com/kubevirt/common-instancetypes/pull/167
[4] https://issues.redhat.com/browse/CNV-40676

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Persistent TPMs are no longer provided by the Windows 11 and Windows 2k22 preferences, this is now deferred until the feature supports RWO storage classes.
```
