### PR TITLE
Fix use of interface multi-queue within `Fedora` and `RHEL/CentOS DPDK` preferences

### DIFF
--- a/preferences/centos/8_stream_dpdk/kustomization.yaml
+++ b/preferences/centos/8_stream_dpdk/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 components:
   - ./metadata
-  - ../../components/cpu-topology-spread
+  - ./requirements
+  - ../../components/cpu-topology-sockets
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"

--- a/preferences/centos/8_stream_dpdk/requirements/kustomization.yaml
+++ b/preferences/centos/8_stream_dpdk/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/centos/8_stream_dpdk/requirements/requirements.yaml
+++ b/preferences/centos/8_stream_dpdk/requirements/requirements.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 1.5Gi

--- a/preferences/centos/9_stream_dpdk/kustomization.yaml
+++ b/preferences/centos/9_stream_dpdk/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 components:
   - ./metadata
-  - ../../components/cpu-topology-spread
+  - ./requirements
+  - ../../components/cpu-topology-sockets
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"

--- a/preferences/centos/9_stream_dpdk/requirements/kustomization.yaml
+++ b/preferences/centos/9_stream_dpdk/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/centos/9_stream_dpdk/requirements/requirements.yaml
+++ b/preferences/centos/9_stream_dpdk/requirements/requirements.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 1.5Gi

--- a/preferences/fedora/kustomization.yaml
+++ b/preferences/fedora/kustomization.yaml
@@ -12,7 +12,6 @@ components:
   - ../components/interfacemodel-virtio-net
   - ../components/rng
   - ../components/secureboot
-  - ../components/interface-multiqueue
 
 patches:
   - target:

--- a/preferences/rhel/8_dpdk/kustomization.yaml
+++ b/preferences/rhel/8_dpdk/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 components:
   - ./metadata
-  - ../../components/cpu-topology-spread
+  - ./requirements
+  - ../../components/cpu-topology-sockets
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"

--- a/preferences/rhel/8_dpdk/requirements/kustomization.yaml
+++ b/preferences/rhel/8_dpdk/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/rhel/8_dpdk/requirements/requirements.yaml
+++ b/preferences/rhel/8_dpdk/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 1.5Gi

--- a/preferences/rhel/9_dpdk/kustomization.yaml
+++ b/preferences/rhel/9_dpdk/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 components:
   - ./metadata
-  - ../../components/cpu-topology-spread
+  - ./requirements
+  - ../../components/cpu-topology-sockets
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"

--- a/preferences/rhel/9_dpdk/requirements/kustomization.yaml
+++ b/preferences/rhel/9_dpdk/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/rhel/9_dpdk/requirements/requirements.yaml
+++ b/preferences/rhel/9_dpdk/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3
+  requirements:
+    cpu:
+      guest: 2
+    memory:
+      guest: 1.5Gi


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

https://github.com/kubevirt/kubevirt/pull/12180 has highlighted some issues with the interface multi-queue tunable when coupled with `VirtualMachines` exposing only a single socket to the guest.

This PR addresses two sets of preferences where this tunable is used.

* Fedora - We drop use of the tunable to avoid having to require a larger instance type default elsewhere (containerdisks etc).
* CentOS/RHEL DPDK - We enforce a new requirement of 2 vCPUs exposed as sockets and retain the tunable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The Fedora preference no longer enables interface multi-queue. The CentOS and RHEL DPDK preferences now require at least 2 vCPUs exposed as sockets to the guest to allow interface multi-queue to work correctly.
```
