### PR TITLE
scripts: Default COMMON_INSTANCETYPES_CRI to podman

### DIFF
--- a/scripts/cri.sh
+++ b/scripts/cri.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Default to podman if COMMON_INSTANCETYPES_CRI isn't provided
+COMMON_INSTANCETYPES_CRI=${COMMON_INSTANCETYPES_CRI:-podman}
+
 if [ "${COMMON_INSTANCETYPES_CRI}" == "" ]; then
     /bin/bash -c "$@"
     exit $?


### PR DESCRIPTION
**What this PR does / why we need it**:

Rather than having to remember to set this use a sane default while allowing users to turn it off by using an empty string.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
