### PR TITLE
Introduce OpenSUSE Tumbleweed and Leap preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ centos.stream9.desktop | CentOS Stream 9
 centos.stream9.dpdk | CentOS Stream 9
 cirros | Cirros
 fedora | Fedora
+opensuse.leap | OpenSUSE Leap
+opensuse.tumbleweed | OpenSUSE Tumbleweed
 rhel.7 | Red Hat Enterprise Linux 7
 rhel.7.desktop | Red Hat Enterprise Linux 7
 rhel.8 | Red Hat Enterprise Linux 8

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./fedora
   - ./cirros
   - ./alpine
+  - ./opensuse

--- a/preferences/opensuse/kustomization.yaml
+++ b/preferences/opensuse/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./leap
+  - ./tumbleweed

--- a/preferences/opensuse/leap/kustomization.yaml
+++ b/preferences/opensuse/leap/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ./metadata
+  - ./requirements
+  - ../../components/diskbus-virtio-blk
+  - ../../components/interfacemodel-virtio-net
+  - ../../components/rng
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: opensuse.leap
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: opensuse.leap

--- a/preferences/opensuse/leap/metadata/kustomization.yaml
+++ b/preferences/opensuse/leap/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/opensuse/leap/metadata/metadata.yaml
+++ b/preferences/opensuse/leap/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,opensuse.leap"
+    iconClass: "icon-opensuse-leap"
+    openshift.io/display-name: "OpenSUSE Leap"

--- a/preferences/opensuse/leap/requirements/kustomization.yaml
+++ b/preferences/opensuse/leap/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/opensuse/leap/requirements/requirements.yaml
+++ b/preferences/opensuse/leap/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://en.opensuse.org/Hardware_requirements
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi

--- a/preferences/opensuse/tumbleweed/kustomization.yaml
+++ b/preferences/opensuse/tumbleweed/kustomization.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+components:
+  - ./metadata
+  - ./requirements
+  - ../../components/diskbus-virtio-blk
+  - ../../components/interfacemodel-virtio-net
+  - ../../components/rng
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: opensuse.tumbleweed
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: opensuse.tumbleweed

--- a/preferences/opensuse/tumbleweed/metadata/kustomization.yaml
+++ b/preferences/opensuse/tumbleweed/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/opensuse/tumbleweed/metadata/metadata.yaml
+++ b/preferences/opensuse/tumbleweed/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,opensuse.tumbleweed"
+    iconClass: "icon-opensuse-tumbleweed"
+    openshift.io/display-name: "OpenSUSE Tumbleweed"

--- a/preferences/opensuse/tumbleweed/requirements/kustomization.yaml
+++ b/preferences/opensuse/tumbleweed/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/opensuse/tumbleweed/requirements/requirements.yaml
+++ b/preferences/opensuse/tumbleweed/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://en.opensuse.org/Hardware_requirements
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 2Gi

--- a/scripts/cri.sh
+++ b/scripts/cri.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-# Default to podman if COMMON_INSTANCETYPES_CRI isn't provided
-COMMON_INSTANCETYPES_CRI=${COMMON_INSTANCETYPES_CRI:-podman}
-
 if [ "${COMMON_INSTANCETYPES_CRI}" == "" ]; then
     /bin/bash -c "$@"
     exit $?

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -120,6 +120,10 @@ var _ = Describe("Common instance types func tests", func() {
 				[]testFn{expectSSHToRunCommandOnLinux("ubuntu")}),
 			Entry("[test_id:10743] Ubuntu 22.04", ubuntu2204ContainerDisk, "ubuntu",
 				[]testFn{expectSSHToRunCommandOnLinux("ubuntu")}),
+			Entry("[test_id:TODO] OpenSUSE Tumbleweed", openSUSETumbleweedContainerDisk, "opensuse.tumbleweed",
+				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("opensuse")}),
+			Entry("[test_id:TODO] OpenSUSE Leap 15.6", openSUSELeapContainerDisk, "opensuse.leap",
+				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("opensuse")}),
 		)
 
 		DescribeTable("a Windows guest with", func(containerDisk, preference string, testFns []testFn) {

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -22,38 +22,42 @@ import (
 const (
 	testNamespace = "common-instancetype-functest"
 
-	defaultFedoraContainerDisk        = "quay.io/containerdisks/fedora:latest"
-	defaultCentos7ContainerDisk       = "quay.io/containerdisks/centos:7-2009"
-	defaultCentosStream8ContainerDisk = "quay.io/containerdisks/centos-stream:8"
-	defaultCentosStream9ContainerDisk = "quay.io/containerdisks/centos-stream:9"
-	defaultUbuntu1804ContainerDisk    = "quay.io/containerdisks/ubuntu:18.04"
-	defaultUbuntu2004ContainerDisk    = "quay.io/containerdisks/ubuntu:20.04"
-	defaultUbuntu2204ContainerDisk    = "quay.io/containerdisks/ubuntu:22.04"
-	defaultValidationOsContainerDisk  = "registry:5000/validation-os-container-disk:latest"
-	defaultWindows10ContainerDisk     = "registry:5000/windows10-container-disk:latest"
-	defaultWindows11ContainerDisk     = "registry:5000/windows11-container-disk:latest"
-	defaultWindows2k16ContainerDisk   = "registry:5000/windows2k16-container-disk:latest"
-	defaultWindows2k19ContainerDisk   = "registry:5000/windows2k19-container-disk:latest"
-	defaultWindows2k22ContainerDisk   = "registry:5000/windows2k22-container-disk:latest"
+	defaultFedoraContainerDisk             = "quay.io/containerdisks/fedora:latest"
+	defaultCentos7ContainerDisk            = "quay.io/containerdisks/centos:7-2009"
+	defaultCentosStream8ContainerDisk      = "quay.io/containerdisks/centos-stream:8"
+	defaultCentosStream9ContainerDisk      = "quay.io/containerdisks/centos-stream:9"
+	defaultUbuntu1804ContainerDisk         = "quay.io/containerdisks/ubuntu:18.04"
+	defaultUbuntu2004ContainerDisk         = "quay.io/containerdisks/ubuntu:20.04"
+	defaultUbuntu2204ContainerDisk         = "quay.io/containerdisks/ubuntu:22.04"
+	defaultOpenSUSETumbleweedContainerDisk = "quay.io/containerdisks/opensuse-tumbleweed:1.0.0"
+	defaultOpenSUSELeapContainerDisk       = "quay.io/containerdisks/opensuse-leap:15.6"
+	defaultValidationOsContainerDisk       = "registry:5000/validation-os-container-disk:latest"
+	defaultWindows10ContainerDisk          = "registry:5000/windows10-container-disk:latest"
+	defaultWindows11ContainerDisk          = "registry:5000/windows11-container-disk:latest"
+	defaultWindows2k16ContainerDisk        = "registry:5000/windows2k16-container-disk:latest"
+	defaultWindows2k19ContainerDisk        = "registry:5000/windows2k19-container-disk:latest"
+	defaultWindows2k22ContainerDisk        = "registry:5000/windows2k22-container-disk:latest"
 )
 
 var (
 	afterSuiteReporters []Reporter
 	virtClient          kubecli.KubevirtClient
 
-	fedoraContainerDisk        string
-	centos7ContainerDisk       string
-	centosStream8ContainerDisk string
-	centosStream9ContainerDisk string
-	ubuntu1804ContainerDisk    string
-	ubuntu2004ContainerDisk    string
-	ubuntu2204ContainerDisk    string
-	validationOsContainerDisk  string
-	windows10ContainerDisk     string
-	windows11ContainerDisk     string
-	windows2k16ContainerDisk   string
-	windows2k19ContainerDisk   string
-	windows2k22ContainerDisk   string
+	fedoraContainerDisk             string
+	centos7ContainerDisk            string
+	centosStream8ContainerDisk      string
+	centosStream9ContainerDisk      string
+	ubuntu1804ContainerDisk         string
+	ubuntu2004ContainerDisk         string
+	ubuntu2204ContainerDisk         string
+	validationOsContainerDisk       string
+	windows10ContainerDisk          string
+	windows11ContainerDisk          string
+	windows2k16ContainerDisk        string
+	windows2k19ContainerDisk        string
+	windows2k22ContainerDisk        string
+	openSUSETumbleweedContainerDisk string
+	openSUSELeapContainerDisk       string
 )
 
 //nolint:gochecknoinits
@@ -74,6 +78,10 @@ func init() {
 		defaultUbuntu2004ContainerDisk, "Ubuntu 20.04 container disk used by functional tests")
 	flag.StringVar(&ubuntu2204ContainerDisk, "ubuntu-2204-container-disk",
 		defaultUbuntu2204ContainerDisk, "Ubuntu 22.04 container disk used by functional tests")
+	flag.StringVar(&openSUSETumbleweedContainerDisk, "opensuse-tumbleweed-container-disk",
+		defaultOpenSUSETumbleweedContainerDisk, "OpenSUSE Tumbleweed container disk used by functional tests")
+	flag.StringVar(&openSUSELeapContainerDisk, "opensuse-leap-container-disk",
+		defaultOpenSUSELeapContainerDisk, "OpenSUSE Leap container disk used by functional tests")
 	flag.StringVar(&validationOsContainerDisk, "validation-os-container-disk",
 		defaultValidationOsContainerDisk, "Validation OS container disk used by functional tests")
 	flag.StringVar(&windows10ContainerDisk, "windows-10-container-disk",


### PR DESCRIPTION
**What this PR does / why we need it**:

These are currently unversioned as Tumbleweed is a rolling distro and Leap's requirements align across the supported versions. When this changes we will look into versioned preferences as with other distros like RHEL etc. SLES preferences will be introduced by a future change but should also align with Leap.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OpenSUSE Tumbleweed and Leap preferences have been added to the project.
```
