### PR TITLE
centos.7,centos.stream8: Mark as deprecated with recent EOLs

### DIFF
--- a/preferences/centos/7/kustomization.yaml
+++ b/preferences/centos/7/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/deprecated
 
 nameSuffix: ".7"

--- a/preferences/centos/8_stream/kustomization.yaml
+++ b/preferences/centos/8_stream/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/deprecated
 
 nameSuffix: ".stream8"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
CentOS 7 and CentOS Stream 8 preferences have been deprecated with the recent EOL of the versions and will be removed in a future release of common-instancetypes.
```
