### PR TITLE
feat: deploy and functest make tasks

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,6 +50,8 @@ The following targets are provided by the `Makefile`
 * `make kubeconform`: Install vendored `kubeconform` from `./tools` into `./_bin`.
 * `make yq`: Install vendored `yq` from `./tools` into `./_bin`.
 * `make golangci-lint`: Install `golangci-lint` version specified in `Makefile` into `./_bin`.
+* `make deploy`: Deploy `common-instancetypes` to an external cluster.
+* `make functest`: Run functest against an external cluster.
 
 ## Running Makefile targets within a container
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ YQ_PACKAGE ?= github.com/mikefarah/yq/v4
 # Version of golangci-lint to install
 GOLANGCI_LINT_VERSION ?= v1.55.2
 
+# Kubeconfig default value
+KUBECONFIG ?= ~/.kube/config
+
 .PHONY: all
 all: lint validate readme test-lint test
 
@@ -40,6 +43,14 @@ lint: generate
 .PHONY: generate
 generate: kustomize yq
 	scripts/generate.sh
+
+.PHONY: deploy
+deploy: lint
+	scripts/deploy-kubevirt-and-cdi.sh && KUBECTL=kubectl scripts/sync.sh
+
+.PHONY: functest
+functest:
+	cd tests && KUBECONFIG=$(KUBECONFIG) go test -v -timeout 0 ./functests/... -ginkgo.v -ginkgo.randomize-all $(FUNCTEST_EXTRA_ARGS)
 
 .PHONY: validate
 validate: generate schema kubeconform

--- a/scripts/deploy-kubevirt-and-cdi.sh
+++ b/scripts/deploy-kubevirt-and-cdi.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+function latest_version() {
+  local repo="$1"
+  curl -s https://api.github.com/repos/kubevirt/"${repo}"/releases/latest | \
+    grep '"tag_name":' | \
+    sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+
+# Deploying kubevirt
+KUBEVIRT_VERSION=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)
+KUBEVIRT_NAMESPACE=${1:-kubevirt}
+
+kubectl apply -n "${KUBEVIRT_NAMESPACE}" -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
+kubectl apply -n "${KUBEVIRT_NAMESPACE}" -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
+
+kubectl patch -n "${KUBEVIRT_NAMESPACE}" kubevirt kubevirt --type='json' -p '[{
+  "op": "add",
+  "path": "/spec/configuration/developerConfiguration/featureGates/-",
+  "value": "NUMA",
+},{
+  "op": "add",
+  "path": "/spec/configuration/developerConfiguration/featureGates/-",
+  "value": "GPU",
+}]'
+
+echo "Waiting for Kubevirt to be ready..."
+kubectl wait --for=condition=Available --timeout=600s -n "${KUBEVIRT_NAMESPACE}" kv/kubevirt
+
+
+# Deploying CDI
+CDI_VERSION=$(latest_version "containerized-data-importer")
+CDI_NAMESPACE=cdi
+
+kubectl apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"
+kubectl apply -n ${CDI_NAMESPACE} -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
+
+echo "Waiting for CDI to be ready..."
+kubectl wait --for=condition=Available --timeout=600s -n ${CDI_NAMESPACE} cdi/cdi


### PR DESCRIPTION
This tasks are helpful when working wieh an external Kubernetes cluster.

The 'deploy' task installs the bundels and their dependencies, whilw the 'functest' task runs the function tests against the cluster.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No issue writen

**Special notes for your reviewer**:
The file `deploy-kubevirt-and-cdi` is very similar to the one in the ssp-operator repository. The plan is to update it in the other repository if the one there gets merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
