### PR TITLE
kubevirt: Support kind kubevirtci providers

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -48,7 +48,7 @@ function kubevirt::down() {
 }
 
 function kubevirt::sync() {
-  KUBECTL=${_kubectl} "${_base_dir}/scripts/sync.sh"
+  KUBECTL=${_kubectl} BASEDIR=${_base_dir} "${_base_dir}/scripts/sync.sh"
 }
 
 function kubevirt::sync-containerdisks() {
@@ -72,6 +72,8 @@ function kubevirt::functest() {
 }
 
 kubevirt::install
+
+cd "${_base_dir}"/_kubevirt
 
 case ${_action} in
   "up")
@@ -109,4 +111,6 @@ case ${_action} in
     exit 1
     ;;
 esac
+
+cd "${_base_dir}"
 

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -75,7 +75,7 @@ function kubevirtci::down() {
 }
 
 function kubevirtci::sync() {
-  KUBECTL=${_kubectl} "${_base_dir}/scripts/sync.sh"
+  KUBECTL=${_kubectl} BASEDIR=${_base_dir} "${_base_dir}/scripts/sync.sh"
 }
 
 function kubevirtci::sync-containerdisks() {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -20,7 +20,8 @@ if [ -z "${KUBECTL}" ]; then
     echo "${BASH_SOURCE[0]} expects the following env variables to be provided: KUBECTL."
     exit 1
 fi
+
 ${KUBECTL} delete VirtualMachineClusterInstancetypes -l instancetype.kubevirt.io/vendor=kubevirt.io
 ${KUBECTL} delete VirtualMachineClusterPreferences -l instancetype.kubevirt.io/vendor=kubevirt.io
-${KUBECTL} kustomize VirtualMachineClusterInstancetypes | ${KUBECTL} apply -f -
-${KUBECTL} kustomize VirtualMachineClusterPreferences | ${KUBECTL} apply -f -
+${KUBECTL} apply -k "${BASEDIR}"/VirtualMachineClusterInstancetypes
+${KUBECTL} apply -k "${BASEDIR}"/VirtualMachineClusterPreferences


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

Kind providers currently expect to be called from the root of the kubevirtci directory. This change supports them and the k8s providers by switching into this directory before returning after each command.

The sync command is also passed the original common-instancetypes directory and now uses the `-k` option of `kubectl apply` to build and apply resources in a single step.

The aim is to then use this support to provide CI coverage for new arm64 based preferences in the near future.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
