### PR TITLE
Fix instance type and preference unit tests

### DIFF
--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -21,11 +21,13 @@ const (
 var _ = Describe("Common instance types unit tests", func() {
 
 	skipLabels := map[string]bool{
+		"instancetype.kubevirt.io/arch":                         true,
 		"instancetype.kubevirt.io/os-type":                      true,
 		"instancetype.kubevirt.io/deprecated":                   true,
 		"instancetype.kubevirt.io/common-instancetypes-version": true,
 		"instancetype.kubevirt.io/version":                      true,
 		"instancetype.kubevirt.io/class":                        true,
+		"instancetype.kubevirt.io/icon-pf":                      true,
 	}
 
 	instanceTypeFunctionMap := map[string]func(string, string, instancetypev1beta1.VirtualMachineClusterInstancetype) error{

--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -20,11 +20,6 @@ const (
 
 var _ = Describe("Common instance types unit tests", func() {
 
-	var (
-		testsClusterPreferences  []instancetypev1beta1.VirtualMachineClusterPreference
-		testsClusterInstanceType []instancetypev1beta1.VirtualMachineClusterInstancetype
-	)
-
 	skipLabels := map[string]bool{
 		"instancetype.kubevirt.io/os-type":                      true,
 		"instancetype.kubevirt.io/deprecated":                   true,
@@ -49,21 +44,15 @@ var _ = Describe("Common instance types unit tests", func() {
 		"instancetype.kubevirt.io/vendor": preferenceCheckVendor,
 	}
 
-	BeforeEach(func() {
-		// Restore resources to make sure we have unchanged data
-		copy(testsClusterPreferences, loadedVirtualMachineClusterPreferences)
-		copy(testsClusterInstanceType, loadedVirtualMachineClusterInstanceTypes)
-	})
-
 	Context("VirtualMachineClusterPreference", func() {
 		It("check version", func() {
-			for _, preference := range testsClusterPreferences {
+			for _, preference := range loadedVirtualMachineClusterPreferences {
 				Expect(preference.APIVersion).To(Equal(expectedVersion))
 			}
 		})
 
 		It("check if labels match resources", func() {
-			for _, preference := range testsClusterPreferences {
+			for _, preference := range loadedVirtualMachineClusterPreferences {
 				for key, value := range preference.Labels {
 					if skipLabels[key] {
 						continue
@@ -78,13 +67,13 @@ var _ = Describe("Common instance types unit tests", func() {
 
 	Context("VirtualMachineClusterInstanceType", func() {
 		It("check version", func() {
-			for _, instanceType := range testsClusterInstanceType {
+			for _, instanceType := range loadedVirtualMachineClusterInstanceTypes {
 				Expect(instanceType.APIVersion).To(Equal(expectedVersion))
 			}
 		})
 
 		It("check if labels match resources", func() {
-			for _, instanceType := range testsClusterInstanceType {
+			for _, instanceType := range loadedVirtualMachineClusterInstanceTypes {
 				for key, value := range instanceType.Labels {
 					if skipLabels[key] {
 						continue


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously none of the loaded resources were copied into the test resource slices as the associated slices were left as nil and thus the call to copy didn't actually copy anything.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
