### PR TITLE
preferences: Set vm.kubevirt.io/os within eventual VMI

### DIFF
--- a/preferences/base/metadata/metadata.yaml
+++ b/preferences/base/metadata/metadata.yaml
@@ -9,3 +9,6 @@ metadata:
     openshift.io/support-url: "https://github.com/kubevirt/common-instancetypes/issues"
   labels:
     instancetype.kubevirt.io/os-type: "linux"
+spec:
+  annotations:
+    vm.kubevirt.io/os: linux

--- a/preferences/windows/base/metadata/metadata.yaml
+++ b/preferences/windows/base/metadata/metadata.yaml
@@ -8,3 +8,6 @@ metadata:
     iconClass: "icon-windows"
   labels:
     instancetype.kubevirt.io/os-type: "windows"
+spec:
+  annotations:
+    vm.kubevirt.io/os: "windows"


### PR DESCRIPTION
/cc @0xFelix 
/cherry-pick release-1.0

**What this PR does / why we need it**:

This annotation while not defined in the KubeVirt API reference is used by downstream consumers, most notably the OpenShift Console. This commit brings us in line with common-templates where this annotation is set on the VirtualMachine.

https://github.com/kubevirt/common-templates/blob/c0e482da8195f2fd45a0e19d8a4ee17f66a1d4f7/templates/windows10.tpl.yaml#L97

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`vm.kubevirt.io/os` is now set as an annotation on resulting `VirtualMachineInstances` using preferences provided by the common-instancetypes project
```
