### PR TITLE
fix: openapi2jsonlibrary incompatibility on s390x

### DIFF
--- a/scripts/schema.sh
+++ b/scripts/schema.sh
@@ -3,7 +3,7 @@
 set -e
 
 if ! command -v openapi2jsonschema &> /dev/null; then
-    echo "openapi2jsonschema is not installed, see https://github.com/instrumenta/openapi2jsonschema#installation for more details."
+    echo "openapi2jsonschema is not installed, please run 'pip install --no-dependencies openapi2jsonschema jsonref click'."
     exit 1
 fi
 


### PR DESCRIPTION
The recommended openapi2jsonlibrary is incompatible with s390x and outdated since 2019. Consider updating to a newer version released in 2023 for seamless functionality.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: enables s390x

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
