### PR TITLE
[release-0.4] u1.2xmedium: Add size to better align with Windows requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ o1.nano  |  1  |  512Mi
 o1.small  |  1  |  2Gi
 o1.xlarge  |  4  |  16Gi
 u1.2xlarge  |  8  |  32Gi
+u1.2xmedium  |  2  |  4Gi
 u1.4xlarge  |  16  |  64Gi
 u1.8xlarge  |  32  |  128Gi
 u1.large  |  2  |  8Gi

--- a/image/build_windows_containerdisk.sh
+++ b/image/build_windows_containerdisk.sh
@@ -35,7 +35,7 @@ case "$WINDOWS_VERSION" in
   windows11)
     OS_VARIANT=win11
     WINDOWS_ISO_OVERLAYS=(overlays/generic overlays/windows11)
-    DEFAULT_INSTANCETYPE=u1.large
+    DEFAULT_INSTANCETYPE=u1.2xmedium
     DEFAULT_PREFERENCE=windows.11.virtio
     ;;
   windows2k16)

--- a/image/validationos.Dockerfile
+++ b/image/validationos.Dockerfile
@@ -56,11 +56,11 @@ FROM scratch
 
 COPY --from=builder --chown=107:107 /disk.img /disk/
 
-LABEL instancetype.kubevirt.io/default-instancetype u1.large
+LABEL instancetype.kubevirt.io/default-instancetype u1.2xmedium
 LABEL instancetype.kubevirt.io/default-preference windows.11
 LABEL instancetype.kubevirt.io/display-needed true
 
 # Set ENVs for compatibility with crun-vm
-ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE u1.large
+ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE u1.2xmedium
 ENV INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE windows.11
 ENV INSTANCETYPE_KUBEVIRT_IO_DISPLAY_NEEDED true

--- a/instancetypes/u/1/sizes.yaml
+++ b/instancetypes/u/1/sizes.yaml
@@ -54,6 +54,19 @@ spec:
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
 metadata:
+  name: "u1.2xmedium"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "4Gi"
+spec:
+  cpu:
+    guest: 2
+  memory:
+    guest: "4Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
   name: "u1.medium"
   labels:
     instancetype.kubevirt.io/cpu: "1"

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Common instance types func tests", func() {
 
 		It("[test_id:10737] can be created when enough resources are provided", func() {
 			for _, preference := range getClusterPreferences(virtClient) {
-				vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.large"}, &v1.PreferenceMatcher{Name: preference.Name}, false)
+				vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference.Name}, false)
 				vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm)
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -142,7 +142,7 @@ var _ = Describe("Common instance types func tests", func() {
 		)
 
 		DescribeTable("a Windows guest with", func(containerDisk, preference string, testFns []testFn) {
-			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.large"}, &v1.PreferenceMatcher{Name: preference}, true)
+			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference}, true)
 			addContainerDisk(vm, containerDisk)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows 11 has minimum requirements of 2 vCPUs and 4Gi of memory. To better align with these requirements a new u1.2xmedium size is introduced.

This is used within our functional tests replacing the larger u1.large instance type that provided 8Gi of memory.

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>
(cherry picked from commit 42ba37814d8d2356fe07e0d9b6476fb73a7be05d)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new `u1.2xmedium` instance type is now provided to better align with the minimum requirements of 2 vCPUs and 4Gi of RAM for Windows 11
```
