### PR TITLE
feat(dpdk): Spread vCPUs across SocketsCoresThreads

### DIFF
--- a/preferences/components/cpu-topology-spread/cpu-topology-spread.yaml
+++ b/preferences/components/cpu-topology-spread/cpu-topology-spread.yaml
@@ -6,3 +6,6 @@ metadata:
 spec:
   cpu:
     preferredCPUTopology: preferSpread
+    spreadOptions:
+      across: SocketsCoresThreads
+      ratio: 4

--- a/preferences/rhel/8_dpdk/kustomization.yaml
+++ b/preferences/rhel/8_dpdk/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
-  - ../../components/cpu-topology-sockets
+  - ../../components/cpu-topology-spread
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"

--- a/preferences/rhel/9_dpdk/kustomization.yaml
+++ b/preferences/rhel/9_dpdk/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
-  - ../../components/cpu-topology-sockets
+  - ../../components/cpu-topology-spread
   - ../../components/interface-multiqueue
 
 nameSuffix: ".dpdk"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This allows for topologies like:

8 vCPUS -> 1 Socket, 4 Cores, 2 Threads
16 vCPUs -> 2 Sockets, 4 Cores, 2 Threads
[...]

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Spread vCPUs across SocketsCoresThreads in DPDK preferences
```
