### PR TITLE
fix(functests): Test rejection on insufficient resources separately

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -73,10 +73,10 @@ var _ = Describe("Common instance types func tests", func() {
 	})
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
-		It("[test_id:10736] is rejected if it does not provide enough resources", func() {
-			createInstancetype(2, "tiny-instancetype", "64M")
+		It("[test_id:10736] is rejected if it does not provide enough memory resources", func() {
+			createInstancetype(8, "tiny-instancetype-memory", "64M")
 			instanceTypeMatcher := v1.InstancetypeMatcher{
-				Name: "tiny-instancetype",
+				Name: "tiny-instancetype-memory",
 				Kind: "VirtualMachineInstancetype",
 			}
 			for _, preference := range getClusterPreferences(virtClient) {
@@ -89,6 +89,22 @@ var _ = Describe("Common instance types func tests", func() {
 							"insufficient Memory resources of 64M provided by instance type, preference requires %s",
 						preference.Spec.Requirements.Memory.Guest.String(),
 					)))
+			}
+		})
+
+		It("[test_id:TODO] is rejected if it does not provide enough cpu resources", func() {
+			createInstancetype(1, "tiny-instancetype-cpu", "64M")
+			instanceTypeMatcher := v1.InstancetypeMatcher{
+				Name: "tiny-instancetype-cpu",
+				Kind: "VirtualMachineInstancetype",
+			}
+			for _, preference := range getClusterPreferences(virtClient) {
+				if preference.Spec.Requirements.CPU == nil || preference.Spec.Requirements.CPU.Guest < 2 {
+					continue
+				}
+				vm = randomVM(&instanceTypeMatcher, &v1.PreferenceMatcher{Name: preference.Name}, false)
+				_, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).To(MatchError(MatchRegexp("1 vCPU(?:s)? provided by (?:the )?instance type")))
 			}
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Introduce separate tests for insufficient cpu or memory in the functional tests for preference requirements.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
