### PR TITLE
Add instancetype.kubevirt.io/size to all instance types

### DIFF
--- a/instancetypes/cx/1/sizes.yaml
+++ b/instancetypes/cx/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 2
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "2Gi"
+    instancetype.kubevirt.io/size: "medium"
 spec:
   cpu:
     guest: 1
@@ -71,6 +76,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/instancetypes/gn/1/sizes.yaml
+++ b/instancetypes/gn/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/instancetypes/m/1/sizes.yaml
+++ b/instancetypes/m/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "256Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 2
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/instancetypes/n/1/sizes.yaml
+++ b/instancetypes/n/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 16
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 32
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "64"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 64
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 4
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "medium"
 spec:
   cpu:
     guest: 4
@@ -71,6 +76,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 8

--- a/instancetypes/o/1/sizes.yaml
+++ b/instancetypes/o/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 2
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "medium"
 spec:
   cpu:
     guest: 1
@@ -71,6 +76,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "1Gi"
+    instancetype.kubevirt.io/size: "micro"
 spec:
   cpu:
     guest: 1
@@ -84,6 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "512Mi"
+    instancetype.kubevirt.io/size: "nano"
 spec:
   cpu:
     guest: 1
@@ -97,6 +104,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "2Gi"
+    instancetype.kubevirt.io/size: "small"
 spec:
   cpu:
     guest: 1
@@ -110,6 +118,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/instancetypes/rt/1/sizes.yaml
+++ b/instancetypes/rt/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 2
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "medium"
 spec:
   cpu:
     guest: 1
@@ -71,6 +76,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "1Gi"
+    instancetype.kubevirt.io/size: "micro"
 spec:
   cpu:
     guest: 1
@@ -84,6 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "2Gi"
+    instancetype.kubevirt.io/size: "small"
 spec:
   cpu:
     guest: 1
@@ -97,6 +104,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/instancetypes/u/1/sizes.yaml
+++ b/instancetypes/u/1/sizes.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "2xlarge"
 spec:
   cpu:
     guest: 8
@@ -19,6 +20,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "4xlarge"
 spec:
   cpu:
     guest: 16
@@ -32,6 +34,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "8xlarge"
 spec:
   cpu:
     guest: 32
@@ -45,6 +48,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "large"
 spec:
   cpu:
     guest: 2
@@ -58,6 +62,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "2xmedium"
 spec:
   cpu:
     guest: 2
@@ -71,6 +76,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "medium"
 spec:
   cpu:
     guest: 1
@@ -84,6 +90,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "1Gi"
+    instancetype.kubevirt.io/size: "micro"
 spec:
   cpu:
     guest: 1
@@ -97,6 +104,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "512Mi"
+    instancetype.kubevirt.io/size: "nano"
 spec:
   cpu:
     guest: 1
@@ -110,6 +118,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "2Gi"
+    instancetype.kubevirt.io/size: "small"
 spec:
   cpu:
     guest: 1
@@ -123,6 +132,7 @@ metadata:
   labels:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "xlarge"
 spec:
   cpu:
     guest: 4

--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,6 +34,7 @@ var _ = Describe("Common instance types unit tests", func() {
 	instanceTypeFunctionMap := map[string]func(string, string, instancetypev1beta1.VirtualMachineClusterInstancetype) error{
 		"instancetype.kubevirt.io/cpu":                   checkCPU,
 		"instancetype.kubevirt.io/memory":                checkMemory,
+		"instancetype.kubevirt.io/size":                  checkSize,
 		"instancetype.kubevirt.io/hugepages":             checkHugepages,
 		"instancetype.kubevirt.io/gpus":                  checkGPUs,
 		"instancetype.kubevirt.io/numa":                  checkNuma,
@@ -112,6 +114,13 @@ func checkMemory(labelValue, labelName string, instanceType instancetypev1beta1.
 		return fmt.Errorf(instanceTypeErrorMessage, labelName, instanceType.Name)
 	}
 
+	return nil
+}
+
+func checkSize(labelValue, labelName string, instanceType instancetypev1beta1.VirtualMachineClusterInstancetype) error {
+	if strings.Split(instanceType.Name, ".")[1] != labelValue {
+		return fmt.Errorf(instanceTypeErrorMessage, labelName, instanceType.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some additional metadata to help users search through the available resources in an environment.

This label could also be used by admins when extending or customising common-instancetypes with Kustomize through a labelSelector.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
All instance types now provide a `instancetype.kubevirt.io/size` label denoting the size of the resource as also encoded in the name.
```
