### PR TITLE
gn: Deprecate GPU NVIDIA class of instance types

### DIFF
--- a/instancetypes/gn/1/gn1.yaml
+++ b/instancetypes/gn/1/gn1.yaml
@@ -21,6 +21,7 @@ metadata:
     instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/gpus: "true"
+    instancetype.kubevirt.io/deprecated: "true"
 spec:
   gpus:
     - name: "gpu1"


### PR DESCRIPTION
/cc @0xFelix 
/cc @davidvossel 
/kind deprecation

**What this PR does / why we need it**:

This class doesn't really make any sense given the very inflexible nature of hard coding the GPU device within the instance type.

Users should simply provide their own GPU deviceName within the VM and use the universal u1 class of instance types for vCPUs and memory.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `gn1` class of instance types has been deprecated ahead of removal in a future release, users should manually define their required GPUs in their VM while using the `u1` universal class for vCPU and memory resources if still required.
```
