### PR TITLE
cleanup: Remove remains of early functest implementation

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -26,7 +26,6 @@ _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _kubectl="${_base_dir}/_kubevirt/cluster-up/kubectl.sh"
 _kubessh="${_base_dir}/_kubevirt/cluster-up/ssh.sh"
 _kubevirtcicli="${_base_dir}/_kubevirt/cluster-up/cli.sh"
-_virtctl="${_base_dir}/_kubevirt/cluster-up/virtctl.sh"
 _action=$1
 shift
 
@@ -67,10 +66,6 @@ function kubevirt::registry() {
   echo "localhost:${port}"
 }
 
-function kubevirt::functest() {
-  KUBECTL=${_kubectl} VIRTCTL=${_virtctl} "${_base_dir}/scripts/functest.sh"
-}
-
 kubevirt::install
 
 cd "${_base_dir}"/_kubevirt
@@ -94,20 +89,14 @@ case ${_action} in
   "registry")
     kubevirt::registry
     ;;
-  "functest")
-    kubevirt::functest
-    ;;
   "ssh")
     ${_kubessh} "$@"
     ;;
   "kubectl")
     ${_kubectl} "$@"
     ;;
-  "virtctl")
-    ${_virtctl} "$@"
-    ;;
   *)
-    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl', 'functest'"
+    echo "No command provided, known commands are 'up', 'down', 'sync', 'ssh', 'kubeconfig', 'registry', 'kubectl'"
     exit 1
     ;;
 esac


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Remove the no longer used functest and virtctl commands from scripts/kubevirt.sh and scripts/kubevirtci.sh.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
