### PR TITLE
rhel.10: Enable secureboot

### DIFF
--- a/preferences/rhel/10/amd64/kustomization.yaml
+++ b/preferences/rhel/10/amd64/kustomization.yaml
@@ -11,5 +11,6 @@ components:
   - ../../../components/disk-dedicatediothread
   - ../../../components/efi
   - ../../../components/rng
+  - ../../../components/secureboot
 
 nameSuffix: ".10"


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest guest images can now boot with secure boot enabled so reflect this in the base amd64 preference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `rhel.10` preference now enables secureboot
```
