### PR TITLE
chore: Add flag for setting timeout for creating windows vms

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	vmReadyTimeout = 300 * time.Second
-	sshPort        = 22
+	sshPort = 22
 )
 
 type testFn func(kubecli.KubevirtClient, string)
@@ -157,7 +156,7 @@ var _ = Describe("Common instance types func tests", func() {
 			addCloudInitWithAuthorizedKey(vm, privKey)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			expectVMToBeReady(virtClient, vm.Name)
+			expectVMToBeReady(virtClient, vm.Name, defaultVMReadyTimeout)
 			for _, testFn := range testFns {
 				testFn(virtClient, vm.Name)
 			}
@@ -197,7 +196,7 @@ var _ = Describe("Common instance types func tests", func() {
 			addContainerDisk(vm, containerDisk)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			expectVMToBeReady(virtClient, vm.Name)
+			expectVMToBeReady(virtClient, vm.Name, windowsReadyTimeout)
 			for _, testFn := range testFns {
 				testFn(virtClient, vm.Name)
 			}
@@ -326,7 +325,7 @@ func addCloudInitWithAuthorizedKey(vm *v1.VirtualMachine, privKey ed25519.Privat
 	vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, vol)
 }
 
-func expectVMToBeReady(virtClient kubecli.KubevirtClient, vmName string) {
+func expectVMToBeReady(virtClient kubecli.KubevirtClient, vmName string, vmReadyTimeout time.Duration) {
 	Eventually(func(g Gomega) {
 		vm, err := virtClient.VirtualMachine(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 		g.Expect(err).ToNot(HaveOccurred())
@@ -338,7 +337,7 @@ func expectGuestAgentToBeConnected(virtClient kubecli.KubevirtClient, vmName str
 	Eventually(func(g Gomega) {
 		_, err := virtClient.VirtualMachineInstance(testNamespace).GuestOsInfo(context.Background(), vmName)
 		g.Expect(err).ToNot(HaveOccurred())
-	}, vmReadyTimeout, 10*time.Second).Should(Succeed())
+	}, defaultVMReadyTimeout, 10*time.Second).Should(Succeed())
 }
 
 func expectSSHToRunCommandOnWindows(virtClient kubecli.KubevirtClient, vmName string) {
@@ -367,5 +366,5 @@ func expectSSHToRunCommand(virtClient kubecli.KubevirtClient, vmName, username s
 
 		err = session.Run("echo hello")
 		g.Expect(err).ToNot(HaveOccurred())
-	}, vmReadyTimeout, 10*time.Second).Should(Succeed())
+	}, defaultVMReadyTimeout, 10*time.Second).Should(Succeed())
 }

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	ginkgo_reporters "github.com/onsi/ginkgo/v2/reporters"
@@ -42,6 +43,8 @@ const (
 	defaultWindows2k19ContainerDisk        = "registry:5000/windows2k19-container-disk:latest"
 	defaultWindows2k22ContainerDisk        = "registry:5000/windows2k22-container-disk:latest"
 	defaultWindows2k25ContainerDisk        = "registry:5000/windows2k25-container-disk:latest"
+
+	defaultVMReadyTimeout = 300 * time.Second
 )
 
 var (
@@ -68,6 +71,8 @@ var (
 	openSUSETumbleweedContainerDisk string
 	openSUSELeap15ContainerDisk     string
 	sles15ContainerDisk             string
+
+	windowsReadyTimeout time.Duration
 )
 
 //nolint:gochecknoinits
@@ -114,6 +119,8 @@ func init() {
 		defaultWindows2k22ContainerDisk, "Windows Server 2022 container disk used by functional tests")
 	flag.StringVar(&windows2k25ContainerDisk, "windows-2k25-container-disk",
 		defaultWindows2k25ContainerDisk, "Windows Server 2025 container disk used by functional tests")
+	flag.DurationVar(&windowsReadyTimeout, "windows-ready-timeout",
+		defaultVMReadyTimeout, "Duration after Windows VM will timeout")
 }
 
 func checkDeployedResources() {


### PR DESCRIPTION
**What this PR does / why we need it**:
some Windows images require more time to download image.
This commit adds new flag windows-ready-timeout, which
will allow user to set higher timeout only for Windows VMs.
All other OS distributions will use default timeout.

**Release note**:
```
NONE
```
