### PR TITLE
fix: set default version when git describe --tags fails

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -27,7 +27,7 @@ echo "---" > common-clusterpreferences-bundle.yaml
 kustomize build ../VirtualMachineClusterPreferences >> common-clusterpreferences-bundle.yaml
 
 # Add a version to each of the generated resources and calculate the checksum
-COMMON_INSTANCETYPES_VERSION=${COMMON_INSTANCETYPES_VERSION-$(git describe --tags)}
+COMMON_INSTANCETYPES_VERSION=${COMMON_INSTANCETYPES_VERSION-$(git describe --tags 2>/dev/null || echo "noversion")}
 export COMMON_INSTANCETYPES_VERSION
 for bundle in common-*-bundle.yaml; do
     yq -i '.metadata.labels.["instancetype.kubevirt.io/common-instancetypes-version"]=env(COMMON_INSTANCETYPES_VERSION)' "${bundle}"


### PR DESCRIPTION
While testing in a local environment, I discovered that the command git describe --tags fails, which in turn causes the generation of common instance types to fail.

To address this issue, a default value of "noversion" will be assigned to the variable in the event that the command fails.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
