### PR TITLE
centos, rhel: Fix DPDK preference requirements

### DIFF
--- a/preferences/centos/8_stream_dpdk/requirements/requirements.yaml
+++ b/preferences/centos/8_stream_dpdk/requirements/requirements.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   requirements:
     cpu:
-      guest: 2
+      # required as this preference uses SocketsCoresThreads with a ratio of 4, 1:4:2 == 8 vCPUs
+      guest: 8
     memory:
       guest: 1.5Gi

--- a/preferences/centos/9_stream_dpdk/requirements/requirements.yaml
+++ b/preferences/centos/9_stream_dpdk/requirements/requirements.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   requirements:
     cpu:
-      guest: 2
+      # required as this preference uses SocketsCoresThreads with a ratio of 4, 1:4:2 == 8 vCPUs
+      guest: 8
     memory:
       guest: 1.5Gi

--- a/preferences/rhel/8_dpdk/requirements/requirements.yaml
+++ b/preferences/rhel/8_dpdk/requirements/requirements.yaml
@@ -7,6 +7,7 @@ spec:
   # https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3
   requirements:
     cpu:
-      guest: 2
+      # required as this preference uses SocketsCoresThreads with a ratio of 4, 1:4:2 == 8 vCPUs
+      guest: 8
     memory:
       guest: 1.5Gi

--- a/preferences/rhel/9_dpdk/requirements/requirements.yaml
+++ b/preferences/rhel/9_dpdk/requirements/requirements.yaml
@@ -7,6 +7,7 @@ spec:
   # https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3
   requirements:
     cpu:
-      guest: 2
+      # required as this preference uses SocketsCoresThreads with a ratio of 4, 1:4:2 == 8 vCPUs
+      guest: 8
     memory:
       guest: 1.5Gi


### PR DESCRIPTION
**What this PR does / why we need it**:

These preferences actually require at least 8 vCPUs through their use of
a SocketsCoresThreads spread ratio of 4, mapping to 1 socket, 4 cores
and 2 threads that in turn needs 8 vCPUs [1].

[1] https://kubevirt.io/user-guide/user_workloads/instancetypes/#spreadoptions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
