### PR TITLE
fix: deployment to external cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ generate: kustomize yq
 
 .PHONY: deploy
 deploy: lint
-	scripts/deploy-kubevirt-and-cdi.sh && KUBECTL=kubectl scripts/sync.sh
+	scripts/deploy-kubevirt-and-cdi.sh && KUBECTL=kubectl BASEDIR=$(CURDIR) scripts/sync.sh
 
 .PHONY: functest
 functest:


### PR DESCRIPTION
The sync.sh script requires the definition of a BASEDIR variable to apply the types and preferences.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
