### PR TITLE
Makefile: Remove whitespace from COMMON_INSTANCETYPES_IMAGE_TAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export KUBEVIRT_TAG = main
 # Use the COMMON_INSTANCETYPES_CRI env variable to control if the following targets are executed within a container.
 # Supported runtimes are docker and podman. By default targets run directly on the host.
 export COMMON_INSTANCETYPES_IMAGE = quay.io/kubevirtci/common-instancetypes-builder
-export COMMON_INSTANCETYPES_IMAGE_TAG = v20241017-30aa54a 
+export COMMON_INSTANCETYPES_IMAGE_TAG = v20241017-30aa54a
 
 # Containerdisk image and tag to use for Validation OS functional tests
 export VALIDATION_OS_IMAGE = quay.io/kubevirtci/validation-os-container-disk


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this podman will fail with the following error:

```sh
$ export COMMON_INSTANCETYPES_CRI=podman
$ make
scripts/cri.sh "scripts/lint.sh"
Error: parsing reference "quay.io/kubevirtci/common-instancetypes-builder:v20241017-30aa54a ": invalid reference format make: *** [Makefile:40: lint] Error 125
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
