### PR TITLE
Disable common instancetypes deployment by virt-operator

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -39,7 +39,7 @@ function kubevirt::up() {
   make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 }
 
 function kubevirt::down() {

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -59,7 +59,7 @@ function kubevirtci::up() {
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 }
 
 function kubevirtci::down() {

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -251,7 +251,11 @@ func createInstancetype(cpu int, name, memory string) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func randomVM(instancetype *v1.InstancetypeMatcher, preference *v1.PreferenceMatcher, runStrategy v1.VirtualMachineRunStrategy) *v1.VirtualMachine {
+func randomVM(
+	instancetype *v1.InstancetypeMatcher,
+	preference *v1.PreferenceMatcher,
+	runStrategy v1.VirtualMachineRunStrategy,
+) *v1.VirtualMachine {
 	name := "test-vm-" + k8srand.String(5)
 	return &v1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -259,7 +263,7 @@ func randomVM(instancetype *v1.InstancetypeMatcher, preference *v1.PreferenceMat
 			Namespace: testNamespace,
 		},
 		Spec: v1.VirtualMachineSpec{
-			RunStrategy:  ptr.To(runStrategy),
+			RunStrategy:  &runStrategy,
 			Instancetype: instancetype,
 			Preference:   preference,
 			Template: &v1.VirtualMachineInstanceTemplateSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

$subject, additionally this PR also removes the use of the now deprecated `Running` field by our functional test VMs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
