### PR TITLE
[release-1.0] Windows 11, 2k22: Enable persistent TPMs & EFI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL=/bin/bash
 # Run `make schema` when updating this version and commit the created files.
 # TODO(lyarwood) - Host the expanded JSON schema elsewhere under the kubevirt namespace
 export KUBEVIRT_VERSION = v1.2.0
+export KUBEVIRT_TAG = release-1.2
 
 # Use the COMMON_INSTANCETYPES_CRI env variable to control if the following targets are executed within a container.
 # Supported runtimes are docker and podman. By default targets run directly on the host.

--- a/preferences/components/efi-persisted/efi.yaml
+++ b/preferences/components/efi-persisted/efi.yaml
@@ -6,4 +6,5 @@ metadata:
 spec:
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: false

--- a/preferences/components/efi-persisted/kustomization.yaml
+++ b/preferences/components/efi-persisted/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./efi.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./efi.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/efi/efi.yaml
+++ b/preferences/components/efi/efi.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: efi
+spec:
+  firmware:
+    preferredUseEfi: true
+    preferredUseSecureBoot: false

--- a/preferences/components/efi/kustomization.yaml
+++ b/preferences/components/efi/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./efi.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./efi.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/secureboot/secureboot.yaml
+++ b/preferences/components/secureboot/secureboot.yaml
@@ -7,5 +7,5 @@ spec:
   features:
     preferredSmm: {}
   firmware:
-    preferredUseEfi: true
-    preferredUseSecureBoot: true
+    preferredEfi:
+      secureBoot: true

--- a/preferences/components/tpm/tpm.yaml
+++ b/preferences/components/tpm/tpm.yaml
@@ -5,4 +5,5 @@ metadata:
   name: tpm
 spec:
   devices:
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true

--- a/preferences/windows/11/kustomization.yaml
+++ b/preferences/windows/11/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/efi-persisted
   - ../../components/tpm
   - ../../components/secureboot
 

--- a/preferences/windows/2k22/kustomization.yaml
+++ b/preferences/windows/2k22/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/efi-persisted
   - ../../components/tpm
   - ../../components/secureboot
 

--- a/scripts/cri.sh
+++ b/scripts/cri.sh
@@ -7,5 +7,5 @@ if [ "${COMMON_INSTANCETYPES_CRI}" == "" ]; then
     exit $?
 fi
 
-${COMMON_INSTANCETYPES_CRI} run -v "$(pwd):/common-instancetypes:rw,Z" -e KUBEVIRT_VERSION="${KUBEVIRT_VERSION}" --rm "${COMMON_INSTANCETYPES_IMAGE}:${COMMON_INSTANCETYPES_IMAGE_TAG}" /usr/bin/bash -c "cd /common-instancetypes && $*"
+${COMMON_INSTANCETYPES_CRI} run -v "$(pwd):/common-instancetypes:rw,Z" -e KUBEVIRT_VERSION="${KUBEVIRT_VERSION}" -e KUBEVIRT_TAG="${KUBEVIRT_TAG}" --rm "${COMMON_INSTANCETYPES_IMAGE}:${COMMON_INSTANCETYPES_IMAGE_TAG}" /usr/bin/bash -c "cd /common-instancetypes && $*"
 

--- a/scripts/schema.sh
+++ b/scripts/schema.sh
@@ -7,8 +7,8 @@ if ! command -v openapi2jsonschema &> /dev/null; then
     exit 1
 fi
 
-KUBEVIRT_SWAGGER_URL=https://raw.githubusercontent.com/kubevirt/kubevirt/${KUBEVIRT_VERSION}/api/openapi-spec/swagger.json
-SCHEMA_DIR=_schemas/${KUBEVIRT_VERSION}
+KUBEVIRT_SWAGGER_URL=https://raw.githubusercontent.com/kubevirt/kubevirt/${KUBEVIRT_TAG}/api/openapi-spec/swagger.json
+SCHEMA_DIR=_schemas/${KUBEVIRT_TAG}
 mkdir -p "${SCHEMA_DIR}"
 
 openapi2jsonschema --stand-alone --expanded --strict -o "${SCHEMA_DIR}" "${KUBEVIRT_SWAGGER_URL}"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -14,14 +14,14 @@ fi
 
 # Validate the output of the various kustomization builds available in the repo
 for f in ./ VirtualMachineClusterInstancetypes VirtualMachineClusterPreferences VirtualMachineInstancetypes VirtualMachinePreferences; do
-    if ! kustomize build ${f} | kubeconform -exit-on-error -strict -schema-location "_schemas/${KUBEVIRT_VERSION}/{{ .ResourceKind }}.json" ; then
+    if ! kustomize build ${f} | kubeconform -exit-on-error -strict -schema-location "_schemas/${KUBEVIRT_TAG}/{{ .ResourceKind }}.json" ; then
         exit 1
     fi
 done
 
 # Validate the generated bundles
 for f in _build/common-*-bundle.yaml; do
-    if ! kubeconform -exit-on-error -strict -schema-location "_schemas/${KUBEVIRT_VERSION}/{{ .ResourceKind }}.json"  "${f}" ; then
+    if ! kubeconform -exit-on-error -strict -schema-location "_schemas/${KUBEVIRT_TAG}/{{ .ResourceKind }}.json"  "${f}" ; then
         exit 1
     fi
 done


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/common-instancetypes/pull/247

This includes 7a710bbba409979941f787c61a551bd90630d34e to resolve a conflict

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Persistent EFI and TPM are now provided by the Windows 11 and Windows 2k22 preferences
```
