### PR TITLE
Ensure `commonInstancetypesDeployment` is disabled, wait for resources to be deleted and stop using depreacted FGs 

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -40,6 +40,9 @@ function kubevirt::up() {
 
   echo "enabling feature gates to validate instance types and preferences"
   ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+
+  echo "waiting for kubevirt to become ready, this can take a few minutes..."
+  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 }
 
 function kubevirt::down() {

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -39,7 +39,7 @@ function kubevirt::up() {
   make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m

--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -39,7 +39,7 @@ function kubevirt::up() {
   make cluster-up -C "${_base_dir}/_kubevirt" && make cluster-sync -C "${_base_dir}/_kubevirt"
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -59,7 +59,7 @@ function kubevirtci::up() {
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -59,7 +59,7 @@ function kubevirtci::up() {
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 
   echo "enabling feature gates to validate instance types and preferences"
-  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+  ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enabled": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
 
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
   ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -60,6 +60,9 @@ function kubevirtci::up() {
 
   echo "enabling feature gates to validate instance types and preferences"
   ${_kubectl} patch kv/kubevirt -n kubevirt --type merge -p '{"spec":{"configuration":{"commonInstancetypesDeployment": {"enable": false},"developerConfiguration":{"featureGates": ["GPU", "NUMA", "VMPersistentState"]},"vmStateStorageClass":"nfs-csi"}}}'
+
+  echo "waiting for kubevirt to become ready, this can take a few minutes..."
+  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 }
 
 function kubevirtci::down() {


### PR DESCRIPTION
/cherry-pick release-1.2

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
