### PR TITLE
feat: Disable Windows guest tests on architectures other than amd64

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -186,7 +186,11 @@ var _ = Describe("Common instance types func tests", func() {
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("sles")}),
 		)
 
-		DescribeTable("a Windows guest with", func(containerDisk, preference string, testFns []testFn) {
+		DescribeTable("a Windows guest with", func(containerDisk string, preferences map[string]string, testFns []testFn) {
+			preference, hasArch := preferences[rt.GOARCH]
+			if !hasArch {
+				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", rt.GOARCH))
+			}
 			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
 			addContainerDisk(vm, containerDisk)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -196,19 +200,19 @@ var _ = Describe("Common instance types func tests", func() {
 				testFn(virtClient, vm.Name)
 			}
 		},
-			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, "windows.11",
+			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, map[string]string{"amd64": "windows.11"},
 				[]testFn{expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 10", windows10ContainerDisk, "windows.10.virtio",
+			Entry("[test_id:????] Windows 10", windows10ContainerDisk, map[string]string{"amd64": "windows.10.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 11", windows11ContainerDisk, "windows.11.virtio",
+			Entry("[test_id:????] Windows 11", windows11ContainerDisk, map[string]string{"amd64": "windows.11.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, "windows.2k16.virtio",
+			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, map[string]string{"amd64": "windows.2k16.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, "windows.2k19.virtio",
+			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, map[string]string{"amd64": "windows.2k19.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, "windows.2k22.virtio",
+			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, map[string]string{"amd64": "windows.2k22.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, "windows.2k25.virtio",
+			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, map[string]string{"amd64": "windows.2k25.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
 		)
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: s390x enablement

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
