### PR TITLE
vm spec will use the preference requirements in vm creation test

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -108,6 +108,21 @@ var _ = Describe("Common instance types func tests", func() {
 		})
 
 		It("[test_id:10737] can be created when enough resources are provided", func() {
+			for _, preference := range getClusterPreferences(virtClient) {
+				instanceTypeName := "it-for-" + preference.Name
+				createInstancetype(int(preference.Spec.Requirements.CPU.Guest), instanceTypeName, preference.Spec.Requirements.Memory.Guest.String())
+				instanceTypeMatcher := v1.InstancetypeMatcher{
+					Name: instanceTypeName,
+					Kind: "VirtualMachineInstancetype",
+				}
+
+				vm = randomVM(&instanceTypeMatcher, &v1.PreferenceMatcher{Name: preference.Name}, v1.RunStrategyHalted)
+				vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
+		It("[test_id:TODO] verifies all preferences have at least one compatible instance type", func() {
 			preferenceInstancetypeMap := map[string]string{
 				"centos.stream9.dpdk": "u1.2xlarge",
 				"rhel.8.dpdk":         "u1.2xlarge",


### PR DESCRIPTION
**What this PR does / why we need it**:
- Renamed test `[test_id:10737] can be created when enough resources are provided` to `[test_id:TODO] verifies all preferences have at least one compatible instance type`
- Added test to create an instance type from the preference requirements and create a VM from the created instance type.

This will help verify the VM can be created using the preference requirements provided, especially important for cases when `spread` cpu topology is used.
The old test naming wasn't expressing it's intention.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
