### PR TITLE
add requirements into rhel.9.realtime preference

### DIFF
--- a/preferences/rhel/9_realtime/kustomization.yaml
+++ b/preferences/rhel/9_realtime/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   - ./metadata
   - ./realtime
+  - ./requirements
   - ../../components/cpu-topology-spread
   - ../../components/interface-multiqueue
 

--- a/preferences/rhel/9_realtime/requirements/kustomization.yaml
+++ b/preferences/rhel/9_realtime/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/rhel/9_realtime/requirements/requirements.yaml
+++ b/preferences/rhel/9_realtime/requirements/requirements.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3
+  requirements:
+    cpu:
+      # required as this preference uses SocketsCoresThreads with a ratio of 2
+      guest: 4
+    memory:
+      guest: 4Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing requirements into rhel.9.realtime preference.
The preference is using an empty `spread` cpu topology option which defaults to `2`, this means we should require at least 2 cpu cores for the preference 

**Which issue(s) this PR fixes**
Blocks #287 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
