### PR TITLE
Added dry run to preference requirement test

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -117,7 +117,11 @@ var _ = Describe("Common instance types func tests", func() {
 				}
 
 				vm = randomVM(&instanceTypeMatcher, &v1.PreferenceMatcher{Name: preference.Name}, v1.RunStrategyHalted)
-				vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				vm, err = virtClient.VirtualMachine(testNamespace).Create(
+					context.Background(),
+					vm,
+					metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+				)
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added dry run to preference requirement test to reduce run time

**Special notes for your reviewer**:
discussed #287 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
