### PR TITLE
fedora: Remove use of interface multiqueue

### DIFF
--- a/preferences/fedora/amd64/kustomization.yaml
+++ b/preferences/fedora/amd64/kustomization.yaml
@@ -12,7 +12,6 @@ components:
   - ../../components/interfacemodel-virtio-net
   - ../../components/rng
   - ../../components/secureboot
-  - ../../components/interface-multiqueue
 
 patches:
   - target:

--- a/preferences/fedora/arm64/kustomization.yaml
+++ b/preferences/fedora/arm64/kustomization.yaml
@@ -11,7 +11,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/rng
-  - ../../components/interface-multiqueue
 
 patches:
   - target:

--- a/preferences/fedora/s390x/kustomization.yaml
+++ b/preferences/fedora/s390x/kustomization.yaml
@@ -11,7 +11,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/rng
-  - ../../components/interface-multiqueue
 
 patches:
   - target:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `fedora` preference is the only plain OS level preference shipped with interface multiqueue enabled. The only other preferences that enable this are `rhel.8.dpdk`, `rhel.9.dpdk` and `rhel.9.realtime`.

This is an issue as it essentially blocks vCPU hot plug when using the `fedora` preference, always requiring a restart to plug new vCPUs as sockets. To avoid this interface multiqueue is removed from the `fedora` preference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
`preferredNetworkInterfaceMultiQueue` is no longer enabled by the `fedora` preference
```
