### PR TITLE
chore(builder): Bump to Fedora 41

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Golang is provided to allow running other Makefile targets
 
-FROM quay.io/fedora/fedora-minimal:40
+FROM quay.io/fedora/fedora-minimal:41
 
 RUN microdnf install -y make tar golang python3-pip ShellCheck && microdnf clean all -y
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump the builder image to Fedora 41 to get a newer golang.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
