### PR TITLE
Add generic linux distribution and legacy preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ cirros | Cirros
 fedora | Fedora (amd64)
 fedora.arm64 | Fedora (arm64)
 fedora.s390x | Fedora (s390x)
+linux | Linux Guest
+linux.efi | Linux EFI Guest
 opensuse.leap | OpenSUSE Leap
 opensuse.tumbleweed | OpenSUSE Tumbleweed
 rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ cirros | Cirros
 fedora | Fedora (amd64)
 fedora.arm64 | Fedora (arm64)
 fedora.s390x | Fedora (s390x)
+legacy | Legacy Guest
 linux | Linux Guest
 linux.efi | Linux EFI Guest
 opensuse.leap | OpenSUSE Leap

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -71,7 +71,7 @@ If [hugepages](https://kubevirt.io/user-guide/compute/hugepages/) are requested 
 
 ### `instancetype.kubevirt.io/os-type`
 
-The underlying type of the workload supported by the preference, current values are `linux` or `windows`.
+The underlying type of the workload supported by the preference, current values are `linux`, `windows` or `legacy`.
 
 ### `instancetype.kubevirt.io/arch`
 

--- a/preferences/components/diskbus-scsi/diskbus-scsi.yaml
+++ b/preferences/components/diskbus-scsi/diskbus-scsi.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: diskbus-scsi
+spec:
+  devices:
+    preferredDiskBus: scsi

--- a/preferences/components/diskbus-scsi/kustomization.yaml
+++ b/preferences/components/diskbus-scsi/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./diskbus-scsi.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./diskbus-scsi.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/interfacemodel-e1000/e1000.yaml
+++ b/preferences/components/interfacemodel-e1000/e1000.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: e1000
+spec:
+  devices:
+    preferredInterfaceModel: e1000

--- a/preferences/components/interfacemodel-e1000/kustomization.yaml
+++ b/preferences/components/interfacemodel-e1000/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: e1000.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: e1000.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - ./sles
   - ./linux-efi
   - ./linux
+  - ./legacy

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -12,3 +12,5 @@ resources:
   - ./alpine
   - ./opensuse
   - ./sles
+  - ./linux-efi
+  - ./linux

--- a/preferences/legacy/kustomization.yaml
+++ b/preferences/legacy/kustomization.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ./metadata
+  - ../components/interfacemodel-e1000
+  - ../components/diskbus-scsi
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: legacy
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: legacy

--- a/preferences/legacy/metadata/kustomization.yaml
+++ b/preferences/legacy/metadata/kustomization.yaml
@@ -1,0 +1,12 @@
+
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/legacy/metadata/metadata.yaml
+++ b/preferences/legacy/metadata/metadata.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,legacy"
+    iconClass: "icon-other"
+    openshift.io/display-name: "Legacy Guest"
+  labels:
+    instancetype.kubevirt.io/os-type: "legacy"
+spec:
+  annotations:
+    vm.kubevirt.io/os: "legacy"

--- a/preferences/linux-efi/kustomization.yaml
+++ b/preferences/linux-efi/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../linux
+
+components:
+  - ./metadata
+  - ../components/efi
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.efi
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.efi

--- a/preferences/linux-efi/metadata/kustomization.yaml
+++ b/preferences/linux-efi/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/linux-efi/metadata/metadata.yaml
+++ b/preferences/linux-efi/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux-efi"
+    iconClass: "icon-linux"
+    openshift.io/display-name: "Linux EFI Guest"

--- a/preferences/linux/kustomization.yaml
+++ b/preferences/linux/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ./metadata
+  - ../components/diskbus-virtio-blk
+  - ../components/interfacemodel-virtio-net
+  - ../components/rng
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux

--- a/preferences/linux/metadata/kustomization.yaml
+++ b/preferences/linux/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/linux/metadata/metadata.yaml
+++ b/preferences/linux/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux"
+    iconClass: "icon-linux"
+    openshift.io/display-name: "Linux Guest"

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -72,13 +72,28 @@ var _ = Describe("Common instance types func tests", func() {
 	})
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
+		clusterPreferencesWithRequirements :=
+			func() []instancetypev1beta1.VirtualMachineClusterPreference {
+				clusterPreferences, err := virtClient.VirtualMachineClusterPreference().List(context.Background(), metav1.ListOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterPreferences.Items).ToNot(BeEmpty())
+
+				var completePreferences []instancetypev1beta1.VirtualMachineClusterPreference
+				for _, preference := range clusterPreferences.Items {
+					if preference.Spec.Requirements != nil {
+						completePreferences = append(completePreferences, preference)
+					}
+				}
+				return completePreferences
+			}
+
 		It("[test_id:10736] is rejected if it does not provide enough memory resources", func() {
 			createInstancetype(8, "tiny-instancetype-memory", "64M")
 			instanceTypeMatcher := v1.InstancetypeMatcher{
 				Name: "tiny-instancetype-memory",
 				Kind: "VirtualMachineInstancetype",
 			}
-			for _, preference := range getClusterPreferences(virtClient) {
+			for _, preference := range clusterPreferencesWithRequirements() {
 				vm = randomVM(&instanceTypeMatcher, &v1.PreferenceMatcher{Name: preference.Name}, v1.RunStrategyHalted)
 				_, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).To(MatchError(
@@ -97,7 +112,7 @@ var _ = Describe("Common instance types func tests", func() {
 				Name: "tiny-instancetype-cpu",
 				Kind: "VirtualMachineInstancetype",
 			}
-			for _, preference := range getClusterPreferences(virtClient) {
+			for _, preference := range clusterPreferencesWithRequirements() {
 				if preference.Spec.Requirements.CPU == nil || preference.Spec.Requirements.CPU.Guest < 2 {
 					continue
 				}
@@ -108,7 +123,7 @@ var _ = Describe("Common instance types func tests", func() {
 		})
 
 		It("[test_id:10737] can be created when enough resources are provided", func() {
-			for _, preference := range getClusterPreferences(virtClient) {
+			for _, preference := range clusterPreferencesWithRequirements() {
 				instanceTypeName := "it-for-" + preference.Name
 				createInstancetype(preference.Spec.Requirements.CPU.Guest, instanceTypeName, preference.Spec.Requirements.Memory.Guest.String())
 				instanceTypeMatcher := v1.InstancetypeMatcher{
@@ -131,7 +146,7 @@ var _ = Describe("Common instance types func tests", func() {
 				"windows.11":          "u1.2xmedium",
 				"windows.11.virtio":   "u1.2xmedium",
 			}
-			for _, preference := range getClusterPreferences(virtClient) {
+			for _, preference := range clusterPreferencesWithRequirements() {
 				instancetype := "u1.medium"
 				if pInstancetype, ok := preferenceInstancetypeMap[preference.Name]; ok {
 					instancetype = pInstancetype
@@ -247,13 +262,6 @@ func getClusterInstancetypes(virtClient kubecli.KubevirtClient) []instancetypev1
 	Expect(err).ToNot(HaveOccurred())
 	Expect(clusterInstancetypes.Items).ToNot(BeEmpty())
 	return clusterInstancetypes.Items
-}
-
-func getClusterPreferences(virtClient kubecli.KubevirtClient) []instancetypev1beta1.VirtualMachineClusterPreference {
-	clusterPreferences, err := virtClient.VirtualMachineClusterPreference().List(context.Background(), metav1.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
-	Expect(clusterPreferences.Items).ToNot(BeEmpty())
-	return clusterPreferences.Items
 }
 
 func createInstancetype(cpu uint32, name, memory string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds a generic linux preferences used for non-supported linux guest and a legacy SO agnostic preference.
These preferences may be used directly as a baseline for onboarding other specific distribution preferences. It helps to avoid duplicating the same basic preferences along all specific distribution preferences.

Added preferences are:

* linux-efi: This preference requests: virtio disk, virtio interfaces, rng and secureboot EFI.
* linux-bios: This preference requests: virtio disk, virtio interfaces, rng and BIOS (default option).
* legacy: This preference requests: scsi disk and e1000 interfaces.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added generic bios and efi linux distribution and legacy preferences
```
