### PR TITLE
image: Request a specific golang version in the builder Dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -8,10 +8,10 @@
 #    * [openapi2jsonschema](https://github.com/instrumenta/openapi2jsonschema)
 #
 # Golang is provided to allow running other Makefile targets
+FROM quay.io/kubevirtci/golang:v20250211-4e3c019
+ENV GIMME_GO_VERSION=1.23.7
 
-FROM quay.io/fedora/fedora-minimal:41
-
-RUN microdnf install -y make tar golang python3-pip ShellCheck && microdnf clean all -y
+RUN dnf install -y make tar python3-pip ShellCheck && dnf clean all -y
 
 # yamllint openapi2jsonschema
 RUN pip install yamllint && \


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

To do this we switch over to the currently Fedora 41 based golang image provided
by kubevirtci and use the GIMME_GO_VERSION ENV variable to request a
specific version of golang.

This should allow us to bump the version when required in the future
causing the post submit job to fire rebuilding the actual builder image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
