### PR TITLE
tests: Add flag for expectedVendor to accommodate downstream modifications

### DIFF
--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	expectedVersion          = "instancetype.kubevirt.io/v1beta1"
-	expectedVendor           = "kubevirt.io"
 	instanceTypeErrorMessage = "%s label does not match in instancetype: %s"
 	preferenceErrorMessage   = "%s label does not match in preference: %s"
 )

--- a/tests/unittests/test_suite_test.go
+++ b/tests/unittests/test_suite_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"flag"
 	"io"
 	"os"
 	"testing"
@@ -14,9 +15,19 @@ import (
 )
 
 const (
+	defaultExpectedVendor = "kubevirt.io"
+
 	clusterInstanceTypesBundlePath = "../../_build/common-clusterinstancetypes-bundle.yaml"
 	clusterPreferencesBundlePath   = "../../_build/common-clusterpreferences-bundle.yaml"
 )
+
+var expectedVendor string
+
+//nolint:gochecknoinits
+func init() {
+	flag.StringVar(&expectedVendor, "expected-vendor",
+		defaultExpectedVendor, "expected instancetype.kubevirt.io/vendor value for all resources")
+}
 
 var (
 	loadedVirtualMachineClusterInstanceTypes []instancetypev1beta1.VirtualMachineClusterInstancetype


### PR DESCRIPTION
**What this PR does / why we need it**:

Downstream vendors can obviously change the value of this label and as the unit tests currently run against the generated bundle we need to accommodate this fact in our unit tests.

This change adds a simple flag to allow anyone running the unit tests downstream to provide their own expected value for the vendor label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
