### PR TITLE
Add Debian requirements and avoid skip testing unintended preferences

### DIFF
--- a/preferences/debian/kustomization.yaml
+++ b/preferences/debian/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 
 components:
   - ./metadata
+  - ./requirements
 
 patches:
   - target:

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -72,6 +72,12 @@ var _ = Describe("Common instance types func tests", func() {
 	})
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
+		var skipPreference = map[string]any{
+			"legacy":    nil,
+			"linux":     nil,
+			"linux.efi": nil,
+		}
+
 		clusterPreferencesWithRequirements :=
 			func() []instancetypev1beta1.VirtualMachineClusterPreference {
 				clusterPreferences, err := virtClient.VirtualMachineClusterPreference().List(context.Background(), metav1.ListOptions{})
@@ -80,7 +86,8 @@ var _ = Describe("Common instance types func tests", func() {
 
 				var completePreferences []instancetypev1beta1.VirtualMachineClusterPreference
 				for _, preference := range clusterPreferences.Items {
-					if preference.Spec.Requirements != nil {
+					if _, ok := skipPreference[preference.Name]; !ok {
+						Expect(preference.Spec.Requirements).ToNot(BeNil())
 						completePreferences = append(completePreferences, preference)
 					}
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/kubevirt/common-instancetypes/pull/331 we missed out to include `requirements` to Debian preferences. Moreover, due to the fact that in https://github.com/kubevirt/common-instancetypes/pull/322 we included logic to avoid testing preferences without `requirements`, Debian preference wasn't being tested unintentionally.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
