### PR TITLE
chore(tests): Wire up UNITTEST_EXTRA_ARGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ kubevirt-functest:
 
 .PHONY: test
 test: generate
-	cd tests && go test -v -timeout 0 ./unittests/...
+	cd tests && go test -v -timeout 0 ./unittests/... $(UNITTEST_EXTRA_ARGS) 
 
 .PHONY: test-fmt
 test-fmt:


### PR DESCRIPTION
**What this PR does / why we need it**:

For example this allows a different expected vendor string to be provided to the unit tests:

```
$ UNITTEST_EXTRA_ARGS="--expected-vendor=no.com" make test
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
