### PR TITLE
functests: Allow to specify arch to test preferences for

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
-	rt "runtime"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -183,9 +182,9 @@ var _ = Describe("Common instance types func tests", func() {
 		})
 
 		DescribeTable("a Linux guest with", func(containerDisk string, preferences map[string]string, testFns []testFn) {
-			preference, hasArch := preferences[rt.GOARCH]
+			preference, hasArch := preferences[preferenceArch]
 			if !hasArch {
-				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", rt.GOARCH))
+				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
 			}
 			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.small"}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
 			addContainerDisk(vm, containerDisk)
@@ -237,9 +236,9 @@ var _ = Describe("Common instance types func tests", func() {
 		)
 
 		DescribeTable("a Windows guest with", func(containerDisk string, preferences map[string]string, testFns []testFn) {
-			preference, hasArch := preferences[rt.GOARCH]
+			preference, hasArch := preferences[preferenceArch]
 			if !hasArch {
-				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", rt.GOARCH))
+				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
 			}
 			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
 			addContainerDisk(vm, containerDisk)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the preference-arch flag which allows to specify the architecture to test preferences for. It defaults to the architecture of the first node of the test cluster. Previously preferences were always tested for the arch of the host running the test binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
