### PR TITLE
chore(preferences): Replace usage of `base` by `linux` preference

### DIFF
--- a/preferences/alpine/kustomization.yaml
+++ b/preferences/alpine/kustomization.yaml
@@ -3,13 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../base
+  - ../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../components/diskbus-virtio-blk
-  - ../components/interfacemodel-virtio-net
 
 patches:
   - target:

--- a/preferences/centos/10_stream/kustomization.yaml
+++ b/preferences/centos/10_stream/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
   - ./metadata
   - ./requirements
-  - ../../components/rng
   - ../../components/disk-dedicatediothread
 
 nameSuffix: ".stream10"

--- a/preferences/centos/9_stream/kustomization.yaml
+++ b/preferences/centos/9_stream/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 components:
   - ./metadata
   - ./requirements
-  - ../../components/rng
   - ../../components/disk-dedicatediothread
 
 nameSuffix: ".stream9"

--- a/preferences/centos/base/kustomization.yaml
+++ b/preferences/centos/base/kustomization.yaml
@@ -3,12 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
 
 patches:
   - target:

--- a/preferences/cirros/kustomization.yaml
+++ b/preferences/cirros/kustomization.yaml
@@ -3,13 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../base
+  - ../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../components/diskbus-virtio-blk
-  - ../components/interfacemodel-virtio-net
 
 patches:
   - target:

--- a/preferences/fedora/amd64/kustomization.yaml
+++ b/preferences/fedora/amd64/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
   - ../requirements
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
-  - ../../components/rng
   - ../../components/secureboot
 
 patches:

--- a/preferences/fedora/arm64/kustomization.yaml
+++ b/preferences/fedora/arm64/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
   - ../requirements
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
-  - ../../components/rng
 
 patches:
   - target:

--- a/preferences/fedora/s390x/kustomization.yaml
+++ b/preferences/fedora/s390x/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
   - ../requirements
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
-  - ../../components/rng
 
 patches:
   - target:

--- a/preferences/opensuse/leap/kustomization.yaml
+++ b/preferences/opensuse/leap/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
-  - ../../components/rng
 
 patches:
   - target:

--- a/preferences/opensuse/tumbleweed/kustomization.yaml
+++ b/preferences/opensuse/tumbleweed/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
-  - ../../components/rng
 
 patches:
   - target:

--- a/preferences/rhel/10/amd64/kustomization.yaml
+++ b/preferences/rhel/10/amd64/kustomization.yaml
@@ -10,7 +10,6 @@ components:
   - ./requirements
   - ../../../components/disk-dedicatediothread
   - ../../../components/efi
-  - ../../../components/rng
   - ../../../components/secureboot
 
 nameSuffix: ".10"

--- a/preferences/rhel/10/arm64/kustomization.yaml
+++ b/preferences/rhel/10/arm64/kustomization.yaml
@@ -9,6 +9,5 @@ components:
   - ./metadata
   - ./requirements
   - ../../../components/disk-dedicatediothread
-  - ../../../components/rng
 
 nameSuffix: ".10.arm64"

--- a/preferences/rhel/9/amd64/kustomization.yaml
+++ b/preferences/rhel/9/amd64/kustomization.yaml
@@ -9,7 +9,6 @@ components:
   - ./metadata
   - ./requirements
   - ../../../components/disk-dedicatediothread
-  - ../../../components/rng
   - ../../../components/secureboot
 
 nameSuffix: ".9"

--- a/preferences/rhel/9/arm64/kustomization.yaml
+++ b/preferences/rhel/9/arm64/kustomization.yaml
@@ -9,6 +9,5 @@ components:
   - ./metadata
   - ./requirements
   - ../../../components/disk-dedicatediothread
-  - ../../../components/rng
 
 nameSuffix: ".9.arm64"

--- a/preferences/rhel/base/kustomization.yaml
+++ b/preferences/rhel/base/kustomization.yaml
@@ -3,12 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../base
+  - ../../linux
 
 components:
   - ./metadata
-  - ../../components/diskbus-virtio-blk
-  - ../../components/interfacemodel-virtio-net
 
 patches:
   - target:

--- a/preferences/sles/kustomization.yaml
+++ b/preferences/sles/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../base
+  - ../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../components/diskbus-virtio-blk
-  - ../components/interfacemodel-virtio-net
-  - ../components/rng
 
 patches:
   - target:

--- a/preferences/ubuntu/kustomization.yaml
+++ b/preferences/ubuntu/kustomization.yaml
@@ -3,14 +3,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../base
+  - ../linux
 
 components:
   - ./metadata
   - ./requirements
-  - ../components/diskbus-virtio-blk
-  - ../components/interfacemodel-virtio-net
-  - ../components/rng
 
 patches:
   - target:


### PR DESCRIPTION
**What this PR does / why we need it**:

It replaces the use of `base` by `linux` preference where possible. It helps to keep all the common components, i.e., virtio disk, virtio interfaces and rng of different preferences in one single place. Moreover, the common components of preferences have been dropped. Additionally, as consequence, some preferences now use `rng`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-57428](https://issues.redhat.com/browse/CNV-57428)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
