### PR TITLE
chore(preferences): Switch `scsi` to `sata` in legacy

### DIFF
--- a/preferences/legacy/kustomization.yaml
+++ b/preferences/legacy/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 components:
   - ./metadata
   - ../components/interfacemodel-e1000
-  - ../components/diskbus-scsi
+  - ../components/diskbus-sata
 
 patches:
   - target:


### PR DESCRIPTION
**What this PR does / why we need it**:

It switches from `scsi` to `sata` as preferred disk bus. This is due to the fact that `scsi` in some guests does not provide drivers for the emulated `scsi` models. Therefore, guests cannot boot, it results in either BSOD or rescue mode.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
legacy preference: Switched from `scsi` to `sata` as preferred disk bus
```
