### PR TITLE
feat(preference): Add Windows XP preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,3 +320,4 @@ windows.2k22 | Microsoft Windows Server 2022
 windows.2k22.virtio | Microsoft Windows Server 2022 (virtio)
 windows.2k25 | Microsoft Windows Server 2025
 windows.2k25.virtio | Microsoft Windows Server 2025 (virtio)
+windows.xp | Microsoft Windows XP

--- a/preferences/components/pcihole64/kustomization.yaml
+++ b/preferences/components/pcihole64/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./pcihole64.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./pcihole64.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/pcihole64/pcihole64.yaml
+++ b/preferences/components/pcihole64/pcihole64.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: pcihole64
+spec:
+  annotations:
+    kubevirt.io/disablePCIHole64: "true"

--- a/preferences/windows/kustomization.yaml
+++ b/preferences/windows/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ./10_virtio
   - ./11
   - ./11_virtio
+  - ./xp

--- a/preferences/windows/xp/kustomization.yaml
+++ b/preferences/windows/xp/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ./metadata
+  - ./requirements
+  - ../../components/pcihole64
+
+nameSuffix: ".xp"

--- a/preferences/windows/xp/metadata/kustomization.yaml
+++ b/preferences/windows/xp/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/xp/metadata/metadata.yaml
+++ b/preferences/windows/xp/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows XP"

--- a/preferences/windows/xp/requirements/kustomization.yaml
+++ b/preferences/windows/xp/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/xp/requirements/requirements.yaml
+++ b/preferences/windows/xp/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-xp/bb490858(v=technet.10)#windows-xp-professional-system-requirements
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 128Mi

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -250,12 +250,12 @@ var _ = Describe("Common instance types func tests", func() {
 				map[string]string{"amd64": "debian", "arm64": "debian"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
 		)
 
-		DescribeTable("a Windows guest with", func(containerDisk string, preferences map[string]string, testFns []testFn) {
+		DescribeTable("a Windows guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
 			preference, hasArch := preferences[preferenceArch]
 			if !hasArch {
 				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
 			}
-			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
+			vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
 			addContainerDisk(vm, containerDisk)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -264,19 +264,28 @@ var _ = Describe("Common instance types func tests", func() {
 				testFn(virtClient, vm.Name)
 			}
 		},
-			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, map[string]string{"amd64": "windows.11"},
-				[]testFn{expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 10", windows10ContainerDisk, map[string]string{"amd64": "windows.10.virtio"},
+			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.11"}, []testFn{expectSSHToRunCommandOnWindows}),
+			Entry("[test_id:????] Windows 10", windows10ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.10.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 11", windows11ContainerDisk, map[string]string{"amd64": "windows.11.virtio"},
+			Entry("[test_id:????] Windows 11", windows11ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.11.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, map[string]string{"amd64": "windows.2k16.virtio"},
+			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k16.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, map[string]string{"amd64": "windows.2k19.virtio"},
+			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k19.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, map[string]string{"amd64": "windows.2k22.virtio"},
+			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k22.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, map[string]string{"amd64": "windows.2k25.virtio"},
+			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k25.virtio"},
+				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
+			Entry("[test_id:????] Windows XP", windowsXpContainerDisk, "u1.nano",
+				map[string]string{"amd64": "windows.xp"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
 		)
 	})

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -48,6 +48,7 @@ const (
 	defaultWindows2k19ContainerDisk        = "registry:5000/windows2k19-container-disk:latest"
 	defaultWindows2k22ContainerDisk        = "registry:5000/windows2k22-container-disk:latest"
 	defaultWindows2k25ContainerDisk        = "registry:5000/windows2k25-container-disk:latest"
+	defaultWindowsXpContainerDisk          = "registry:5000/windowsxp-container-disk:latest"
 
 	defaultVMReadyTimeout = 300 * time.Second
 )
@@ -74,6 +75,7 @@ var (
 	windows2k19ContainerDisk        string
 	windows2k22ContainerDisk        string
 	windows2k25ContainerDisk        string
+	windowsXpContainerDisk          string
 	openSUSETumbleweedContainerDisk string
 	openSUSELeap15ContainerDisk     string
 	sles15ContainerDisk             string
@@ -140,6 +142,8 @@ func init() {
 		defaultWindows2k22ContainerDisk, "Windows Server 2022 container disk used by functional tests")
 	flag.StringVar(&windows2k25ContainerDisk, "windows-2k25-container-disk",
 		defaultWindows2k25ContainerDisk, "Windows Server 2025 container disk used by functional tests")
+	flag.StringVar(&windowsXpContainerDisk, "windows-xp-container-disk",
+		defaultWindowsXpContainerDisk, "Windows XP container disk used by functional tests")
 	flag.StringVar(&preferenceArch, "preference-arch", "", "Architecture to test preferences for")
 	flag.DurationVar(&windowsReadyTimeout, "windows-ready-timeout",
 		defaultVMReadyTimeout, "Duration after Windows VM will timeout")


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds `windows.xp` preference, tests and Windows XP container disk flag. Moreover, it adds `unsupported` and `pciHole64` disabler components.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-61449](https://issues.redhat.com/browse/CNV-61449)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `window.xp` preference
```
