### PR TITLE
m1, cx1: Introduce 1Gi hugepage sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,16 +226,27 @@ provided by this project:
 Name | vCPUs | Memory
 -----|-------|-------
 cx1.2xlarge  |  8  |  16Gi
+cx1.2xlarge1gi  |  8  |  16Gi
 cx1.4xlarge  |  16  |  32Gi
+cx1.4xlarge1gi  |  16  |  32Gi
 cx1.8xlarge  |  32  |  64Gi
+cx1.8xlarge1gi  |  32  |  64Gi
 cx1.large  |  2  |  4Gi
+cx1.large1gi  |  2  |  4Gi
 cx1.medium  |  1  |  2Gi
+cx1.medium1gi  |  1  |  2Gi
 cx1.xlarge  |  4  |  8Gi
+cx1.xlarge1gi  |  4  |  8Gi
 m1.2xlarge  |  8  |  64Gi
+m1.2xlarge1gi  |  8  |  64Gi
 m1.4xlarge  |  16  |  128Gi
+m1.4xlarge1gi  |  16  |  128Gi
 m1.8xlarge  |  32  |  256Gi
+m1.8xlarge1gi  |  32  |  256Gi
 m1.large  |  2  |  16Gi
+m1.large1gi  |  2  |  16Gi
 m1.xlarge  |  4  |  32Gi
+m1.xlarge1gi  |  4  |  32Gi
 n1.2xlarge  |  16  |  32Gi
 n1.4xlarge  |  32  |  64Gi
 n1.8xlarge  |  64  |  128Gi

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -65,7 +65,7 @@ If [isolateEmulatorThread](https://kubevirt.io/user-guide/compute/dedicated_cpu_
 
 ### `instancetype.kubevirt.io/hugepages` (optional)
 
-If [hugepages](https://kubevirt.io/user-guide/compute/hugepages/) are requested by the instance type.
+The size of [hugepages](https://kubevirt.io/user-guide/compute/hugepages/) requested by the instance type.
 
 ## Preferences
 

--- a/instancetypes/cx/1/cx1.yaml
+++ b/instancetypes/cx/1/cx1.yaml
@@ -24,14 +24,10 @@ metadata:
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/numa: "true"
-    instancetype.kubevirt.io/hugepages: "true"
 spec:
   cpu:
     dedicatedCPUPlacement: true
     isolateEmulatorThread: true
     numa:
       guestMappingPassthrough: {}
-  memory:
-    hugepages:
-      pageSize: "2Mi"
   ioThreadsPolicy: "auto"

--- a/instancetypes/cx/1/sizes.yaml
+++ b/instancetypes/cx/1/sizes.yaml
@@ -7,11 +7,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "16Gi"
     instancetype.kubevirt.io/size: "2xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 8
   memory:
     guest: "16Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -21,11 +24,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "32Gi"
     instancetype.kubevirt.io/size: "4xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 16
   memory:
     guest: "32Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -35,11 +41,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "64Gi"
     instancetype.kubevirt.io/size: "8xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 32
   memory:
     guest: "64Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -49,11 +58,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "4Gi"
     instancetype.kubevirt.io/size: "large"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 2
   memory:
     guest: "4Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -63,11 +75,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "1"
     instancetype.kubevirt.io/memory: "2Gi"
     instancetype.kubevirt.io/size: "medium"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 1
   memory:
     guest: "2Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -77,8 +92,113 @@ metadata:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "8Gi"
     instancetype.kubevirt.io/size: "xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 4
   memory:
     guest: "8Gi"
+    hugepages:
+      pageSize: "2Mi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.2xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "2xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 8
+  memory:
+    guest: "16Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.4xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "4xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 16
+  memory:
+    guest: "32Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.8xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "8xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 32
+  memory:
+    guest: "64Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.large1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "4Gi"
+    instancetype.kubevirt.io/size: "large1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 2
+  memory:
+    guest: "4Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.medium1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "1"
+    instancetype.kubevirt.io/memory: "2Gi"
+    instancetype.kubevirt.io/size: "medium1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 1
+  memory:
+    guest: "2Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "cx1.xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "8Gi"
+    instancetype.kubevirt.io/size: "xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 4
+  memory:
+    guest: "8Gi"
+    hugepages:
+      pageSize: "1Gi"

--- a/instancetypes/m/1/m1.yaml
+++ b/instancetypes/m/1/m1.yaml
@@ -14,8 +14,4 @@ metadata:
     instancetype.kubevirt.io/icon-pf: "fa-memory"
     instancetype.kubevirt.io/version: "1"
     instancetype.kubevirt.io/vendor: "kubevirt.io"
-    instancetype.kubevirt.io/hugepages: "true"
-spec:
-  memory:
-    hugepages:
-      pageSize: "2Mi"
+spec: {}

--- a/instancetypes/m/1/sizes.yaml
+++ b/instancetypes/m/1/sizes.yaml
@@ -7,11 +7,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "8"
     instancetype.kubevirt.io/memory: "64Gi"
     instancetype.kubevirt.io/size: "2xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 8
   memory:
     guest: "64Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -21,11 +24,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "16"
     instancetype.kubevirt.io/memory: "128Gi"
     instancetype.kubevirt.io/size: "4xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 16
   memory:
     guest: "128Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -35,11 +41,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "32"
     instancetype.kubevirt.io/memory: "256Gi"
     instancetype.kubevirt.io/size: "8xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 32
   memory:
     guest: "256Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -49,11 +58,14 @@ metadata:
     instancetype.kubevirt.io/cpu: "2"
     instancetype.kubevirt.io/memory: "16Gi"
     instancetype.kubevirt.io/size: "large"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 2
   memory:
     guest: "16Gi"
+    hugepages:
+      pageSize: "2Mi"
 ---
 apiVersion: instancetype.kubevirt.io/v1beta1
 kind: VirtualMachineClusterInstancetype
@@ -63,8 +75,96 @@ metadata:
     instancetype.kubevirt.io/cpu: "4"
     instancetype.kubevirt.io/memory: "32Gi"
     instancetype.kubevirt.io/size: "xlarge"
+    instancetype.kubevirt.io/hugepages: "2Mi"
 spec:
   cpu:
     guest: 4
   memory:
     guest: "32Gi"
+    hugepages:
+      pageSize: "2Mi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "m1.2xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "8"
+    instancetype.kubevirt.io/memory: "64Gi"
+    instancetype.kubevirt.io/size: "2xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 8
+  memory:
+    guest: "64Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "m1.4xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "16"
+    instancetype.kubevirt.io/memory: "128Gi"
+    instancetype.kubevirt.io/size: "4xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 16
+  memory:
+    guest: "128Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "m1.8xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "32"
+    instancetype.kubevirt.io/memory: "256Gi"
+    instancetype.kubevirt.io/size: "8xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 32
+  memory:
+    guest: "256Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "m1.large1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "2"
+    instancetype.kubevirt.io/memory: "16Gi"
+    instancetype.kubevirt.io/size: "large1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 2
+  memory:
+    guest: "16Gi"
+    hugepages:
+      pageSize: "1Gi"
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachineClusterInstancetype
+metadata:
+  name: "m1.xlarge1gi"
+  labels:
+    instancetype.kubevirt.io/cpu: "4"
+    instancetype.kubevirt.io/memory: "32Gi"
+    instancetype.kubevirt.io/size: "xlarge1gi"
+    instancetype.kubevirt.io/hugepages: "1Gi"
+spec:
+  cpu:
+    guest: 4
+  memory:
+    guest: "32Gi"
+    hugepages:
+      pageSize: "1Gi"

--- a/instancetypes/n/1/n1.yaml
+++ b/instancetypes/n/1/n1.yaml
@@ -20,7 +20,7 @@ metadata:
     instancetype.kubevirt.io/vendor: "kubevirt.io"
     instancetype.kubevirt.io/dedicatedCPUPlacement: "true"
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
-    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/hugepages: "1Gi"
 spec:
   annotations:
     cpu-load-balancing.crio.io: "disable"

--- a/instancetypes/rt/1/rt1.yaml
+++ b/instancetypes/rt/1/rt1.yaml
@@ -20,7 +20,7 @@ metadata:
     instancetype.kubevirt.io/isolateEmulatorThread: "true"
     instancetype.kubevirt.io/numa: "true"
     instancetype.kubevirt.io/realtime: "true"
-    instancetype.kubevirt.io/hugepages: "true"
+    instancetype.kubevirt.io/hugepages: "1Gi"
 spec:
   annotations:
     cpu-load-balancing.crio.io: disable

--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -123,15 +123,21 @@ func checkSize(labelValue, labelName string, instanceType instancetypev1beta1.Vi
 }
 
 func checkHugepages(labelValue, labelName string, instanceType instancetypev1beta1.VirtualMachineClusterInstancetype) error {
-	boolValue, err := strconv.ParseBool(labelValue)
+	labelQuantity, err := resource.ParseQuantity(labelValue)
 	if err != nil {
 		return err
 	}
-
-	if (instanceType.Spec.Memory.Hugepages == nil && boolValue) || (instanceType.Spec.Memory.Hugepages != nil && !boolValue) {
+	if labelQuantity.IsZero() || instanceType.Spec.Memory.Hugepages == nil || instanceType.Spec.Memory.Hugepages.PageSize == "" {
 		return fmt.Errorf(instanceTypeErrorMessage, labelName, instanceType.Name)
 	}
 
+	specQuantity, err := resource.ParseQuantity(instanceType.Spec.Memory.Hugepages.PageSize)
+	if err != nil {
+		return err
+	}
+	if labelQuantity.Cmp(specQuantity) != 0 {
+		return fmt.Errorf(instanceTypeErrorMessage, labelName, instanceType.Name)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The instancetype.kubevirt.io/hugepages label is also updated to reflect
the size of hugepages requested by the instance type.

n1 and rt1 already provide 1Gi sizes, adding 2Mi sizes for these
specific families is left to a future change if it is ever required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New 1Gi hugepage based sizes affixed with `1gi` have been introduced for the cx1 and m1 instance type families
```
