### PR TITLE
feat(preference): Add generic virtio transitional linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ fedora.s390x | Fedora (s390x)
 legacy | Legacy Guest
 linux | Linux Guest
 linux.efi | Linux EFI Guest
+linux.virtiotransitional | Linux Virtio Transitional Guest
 opensuse.leap | OpenSUSE Leap
 opensuse.tumbleweed | OpenSUSE Tumbleweed
 oraclelinux | Oracle Linux

--- a/preferences/components/virtio-transitional/kustomization.yaml
+++ b/preferences/components/virtio-transitional/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./virtio-transitional.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./virtio-transitional.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/virtio-transitional/virtio-transitional.yaml
+++ b/preferences/components/virtio-transitional/virtio-transitional.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: virtio-transitional
+spec:
+  devices:
+    preferredUseVirtioTransitional: true

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -12,8 +12,9 @@ resources:
   - ./alpine
   - ./opensuse
   - ./sles
-  - ./linux-efi
   - ./linux
+  - ./linux-efi
+  - ./linux-virtio-transitional
   - ./legacy
   - ./debian
   - ./oraclelinux

--- a/preferences/linux-virtio-transitional/kustomization.yaml
+++ b/preferences/linux-virtio-transitional/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../linux
+
+components:
+  - ./metadata
+  - ../components/virtio-transitional
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.virtiotransitional
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.virtiotransitional

--- a/preferences/linux-virtio-transitional/metadata/kustomization.yaml
+++ b/preferences/linux-virtio-transitional/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/linux-virtio-transitional/metadata/metadata.yaml
+++ b/preferences/linux-virtio-transitional/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux-virtio-transitional"
+    iconClass: "icon-linux"
+    openshift.io/display-name: "Linux Virtio Transitional Guest"

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -72,9 +72,10 @@ var _ = Describe("Common instance types func tests", func() {
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
 		var skipPreference = map[string]any{
-			"legacy":    nil,
-			"linux":     nil,
-			"linux.efi": nil,
+			"legacy":                   nil,
+			"linux":                    nil,
+			"linux.efi":                nil,
+			"linux.virtiotransitional": nil,
 		}
 
 		clusterPreferencesWithRequirements :=


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds `linux.virtiotransitional` preference for legacy Linux distributions requiring virtio transitional drivers, e.g., RHEL6.

Moreover, it adds a new component for adding the spec `preferredUseVirtioTransitional`.

Additionally, the `linux.virtiotransitional` has been added to the skip list to avoid the preference for being tested since it does not have `spec.Requirements` field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-62999](https://issues.redhat.com/browse/CNV-62999)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `linux.virtiotransitional` preference for Linux requiring virtio transitional
```
