### PR TITLE
[release-1.0] feat(preference): Add generic virtio transitional linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ fedora | Fedora
 legacy | Legacy Guest
 linux | Linux Guest
 linux.efi | Linux EFI Guest
+linux.virtiotransitional | Linux Virtio Transitional Guest
 oraclelinux | Oracle Linux
 rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)
 rhel.7 | Red Hat Enterprise Linux 7

--- a/preferences/components/virtio-transitional/kustomization.yaml
+++ b/preferences/components/virtio-transitional/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./virtio-transitional.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./virtio-transitional.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/virtio-transitional/virtio-transitional.yaml
+++ b/preferences/components/virtio-transitional/virtio-transitional.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: virtio-transitional
+spec:
+  devices:
+    preferredUseVirtioTransitional: true

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -10,8 +10,9 @@ resources:
   - ./fedora
   - ./cirros
   - ./alpine
-  - ./linux-efi
   - ./linux
+  - ./linux-efi
+  - ./linux-virtio-transitional
   - ./legacy
   - ./debian
   - ./oraclelinux

--- a/preferences/linux-virtio-transitional/kustomization.yaml
+++ b/preferences/linux-virtio-transitional/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../linux
+
+components:
+  - ./metadata
+  - ../components/virtio-transitional
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.virtiotransitional
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: linux.virtiotransitional

--- a/preferences/linux-virtio-transitional/metadata/kustomization.yaml
+++ b/preferences/linux-virtio-transitional/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/linux-virtio-transitional/metadata/metadata.yaml
+++ b/preferences/linux-virtio-transitional/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,linux-virtio-transitional"
+    iconClass: "icon-linux"
+    openshift.io/display-name: "Linux Virtio Transitional Guest"

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -69,9 +69,10 @@ var _ = Describe("Common instance types func tests", func() {
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
 		var skipPreference = map[string]any{
-			"legacy":    nil,
-			"linux":     nil,
-			"linux.efi": nil,
+			"legacy":                   nil,
+			"linux":                    nil,
+			"linux.efi":                nil,
+			"linux.virtiotransitional": nil,
 		}
 
 		clusterPreferencesWithRequirements :=


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubevirt/common-instancetypes/pull/390

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `linux.virtiotransitional` preference for Linux requiring virtio transitional
```
