### PR TITLE
chore(preference): Drop `Beta` from RHEL 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,9 @@ linux.virtiotransitional | Linux Virtio Transitional Guest
 opensuse.leap | OpenSUSE Leap
 opensuse.tumbleweed | OpenSUSE Tumbleweed
 oraclelinux | Oracle Linux
-rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)
-rhel.10.arm64 | Red Hat Enterprise Linux 10 Beta (arm64)
-rhel.10.s390x | Red Hat Enterprise Linux 10 Beta (s390x)
+rhel.10 | Red Hat Enterprise Linux 10 (amd64)
+rhel.10.arm64 | Red Hat Enterprise Linux 10 (arm64)
+rhel.10.s390x | Red Hat Enterprise Linux 10 (s390x)
 rhel.7 | Red Hat Enterprise Linux 7
 rhel.7.desktop | Red Hat Enterprise Linux 7
 rhel.8 | Red Hat Enterprise Linux 8

--- a/preferences/rhel/10/amd64/metadata/metadata.yaml
+++ b/preferences/rhel/10/amd64/metadata/metadata.yaml
@@ -4,6 +4,6 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 10 Beta (amd64)"
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (amd64)"
   labels:
     instancetype.kubevirt.io/arch: "amd64"

--- a/preferences/rhel/10/arm64/metadata/metadata.yaml
+++ b/preferences/rhel/10/arm64/metadata/metadata.yaml
@@ -4,6 +4,6 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 10 Beta (arm64)"
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (arm64)"
   labels:
     instancetype.kubevirt.io/arch: "arm64"

--- a/preferences/rhel/10/s390x/metadata/metadata.yaml
+++ b/preferences/rhel/10/s390x/metadata/metadata.yaml
@@ -4,6 +4,6 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 10 Beta (s390x)"
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (s390x)"
   labels:
     instancetype.kubevirt.io/arch: "s390x"


### PR DESCRIPTION
**What this PR does / why we need it**:

RHEL 10 is no longer on beta state. It drops `Beta` from all architectures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-63515](https://issues.redhat.com/browse/CNV-63515)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Dropped `Beta` from RHEL 10 preferences.
```
