### PR TITLE
[release-1.2] chore(preference): Drop `Beta` from RHEL 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ linux.efi | Linux EFI Guest
 opensuse.leap | OpenSUSE Leap
 opensuse.tumbleweed | OpenSUSE Tumbleweed
 oraclelinux | Oracle Linux
-rhel.10 | Red Hat Enterprise Linux 10 Beta (amd64)
-rhel.10.arm64 | Red Hat Enterprise Linux 10 Beta (arm64)
+rhel.10 | Red Hat Enterprise Linux 10 (amd64)
+rhel.10.arm64 | Red Hat Enterprise Linux 10 (arm64)
 rhel.7 | Red Hat Enterprise Linux 7
 rhel.7.desktop | Red Hat Enterprise Linux 7
 rhel.8 | Red Hat Enterprise Linux 8

--- a/preferences/rhel/10/amd64/metadata/metadata.yaml
+++ b/preferences/rhel/10/amd64/metadata/metadata.yaml
@@ -4,6 +4,6 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 10 Beta (amd64)"
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (amd64)"
   labels:
     instancetype.kubevirt.io/arch: "amd64"

--- a/preferences/rhel/10/arm64/metadata/metadata.yaml
+++ b/preferences/rhel/10/arm64/metadata/metadata.yaml
@@ -4,6 +4,6 @@ kind: VirtualMachinePreference
 metadata:
   name: metadata
   annotations:
-    openshift.io/display-name: "Red Hat Enterprise Linux 10 Beta (arm64)"
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (arm64)"
   labels:
     instancetype.kubevirt.io/arch: "arm64"


### PR DESCRIPTION
Manual backport of https://github.com/kubevirt/common-instancetypes/pull/396

```release-note
Dropped `Beta` from RHEL 10 preferences.
```
