### PR TITLE
feat: e2e tests adjustments

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"golang.org/x/crypto/ssh"
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -399,7 +400,8 @@ func addContainerDisk(vm *v1.VirtualMachine, image string) {
 		Name: "containerdisk-" + k8srand.String(5),
 		VolumeSource: v1.VolumeSource{
 			ContainerDisk: &v1.ContainerDiskSource{
-				Image: image,
+				Image:           image,
+				ImagePullPolicy: k8sv1.PullIfNotPresent,
 			},
 		},
 	}

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -230,7 +230,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	_, err = virtClient.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).ToNot(And(HaveOccurred(), Not(MatchError(errors.IsAlreadyExists, "errors.IsAlreadyExists"))))
 
 	checkDeployedResources()
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: do not fail functest if the common-instancetype-functest namespace exists

In d/s tests we need to prepopulate some big images before tests run.
That means we have to create the namespace in advance. That is causing
the functest to fail.
This PR adds a condition, that if the namespace already exists, do not
fail

feat: set pull policy for container disks in func tests

To be able to prepopulate the images, the tests need to set
pullIfNotPresent pull policy to the container disk.

**Release note**:
```
NONE
```
