### PR TITLE
[release-1.0] chore(test): Add RHEL 6 test

### DIFF
--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -155,6 +155,8 @@ var _ = Describe("Common instance types func tests", func() {
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("centos")}),
 			Entry("[test_id:10745] CentOS Stream 9", centosStream9ContainerDisk, "u1.small", "centos.stream9",
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("cloud-user")}),
+			Entry("[test_id:TODO] RHEL 6", rhel6ContainerDisk, "u1.micro", "linux.virtiotransitional",
+				[]testFn{expectGuestAgentToBeConnected}),
 			Entry("[test_id:TODO] RHEL 7", rhel7ContainerDisk, "u1.micro", "rhel.7",
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("cloud-user")}),
 			Entry("[test_id:TODO] RHEL 8", rhel8ContainerDisk, "u1.small", "rhel.8",

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -27,6 +27,7 @@ const (
 	defaultCentos7ContainerDisk       = "quay.io/containerdisks/centos:7-2009"
 	defaultCentosStream8ContainerDisk = "quay.io/containerdisks/centos-stream:8"
 	defaultCentosStream9ContainerDisk = "quay.io/containerdisks/centos-stream:9"
+	defaultRHEL6ContainerDisk         = "registry:5000/rhel-guest-image:6"
 	defaultRHEL7ContainerDisk         = "registry:5000/rhel-guest-image:7"
 	defaultRHEL8ContainerDisk         = "registry:5000/rhel-guest-image:8"
 	defaultRHEL9ContainerDisk         = "registry:5000/rhel-guest-image:9"
@@ -56,6 +57,7 @@ var (
 	centos7ContainerDisk       string
 	centosStream8ContainerDisk string
 	centosStream9ContainerDisk string
+	rhel6ContainerDisk         string
 	rhel7ContainerDisk         string
 	rhel8ContainerDisk         string
 	rhel9ContainerDisk         string
@@ -89,6 +91,8 @@ func init() {
 		defaultCentosStream8ContainerDisk, "CentOS Stream 8 container disk used by functional tests")
 	flag.StringVar(&centosStream9ContainerDisk, "centos-stream-9-container-disk",
 		defaultCentosStream9ContainerDisk, "CentOS Stream 9 container disk used by functional tests")
+	flag.StringVar(&rhel6ContainerDisk, "rhel-6-container-disk",
+		defaultRHEL6ContainerDisk, "RHEL 6 container disk used by functional tests")
 	flag.StringVar(&rhel7ContainerDisk, "rhel-7-container-disk",
 		defaultRHEL7ContainerDisk, "RHEL 7 container disk used by functional tests")
 	flag.StringVar(&rhel8ContainerDisk, "rhel-8-container-disk",


### PR DESCRIPTION
It onboards a new test for RHEL 6 using `linux.virtiotransitional` preference.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/common-instancetypes/pull/403
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
