### PR TITLE
Bump golangci-lint and golang versions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,10 @@
 # golangci configuration
 # Taken from https://github.com/kubevirt/kubevirt/blob/main/.golangci.yml
+# and additionally ginkgolinter was enabled.
 
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 100
-    statements: 50
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - paramTypeCombine
-      - whyNoLint
-      - wrapperFunc
-    settings:
-      hugeParam:
-        sizeThreshold: 1024
-      rangeValCopy:
-        sizeThreshold: 1024
-  gocyclo:
-    min-complexity: 15
-  mnd:
-    # don't include the "operation" and "assign"
-    checks:
-      - argument
-      - case
-      - condition
-      - return
-  lll:
-    line-length: 140
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
-  stylecheck:
-    dot-import-whitelist:
-      - "github.com/onsi/ginkgo/v2"
-      - "github.com/onsi/gomega"
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - copyloopvar
@@ -65,12 +17,9 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
     - goheader
-    - goimports
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -81,26 +30,100 @@ linters:
     - nolintlint
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
-    - unparam
     - unused
     - whitespace
-
-  # don't enable:
-  # - asciicheck
-  # - scopelint
-  # - gochecknoglobals
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - interfacer
-  # - maligned
-  # - nestif
-  # - prealloc
-  # - testpackage
-  # - revive
-  # - wsl
-
+    - ginkgolinter
+  settings:
+    dupl:
+      threshold: 100
+    funlen:
+      lines: 100
+      statements: 50
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+        - ifElseChain
+        - octalLiteral
+        - paramTypeCombine
+        - whyNoLint
+        - wrapperFunc
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      settings:
+        hugeParam:
+          sizeThreshold: 1024
+        rangeValCopy:
+          sizeThreshold: 1024
+    gocyclo:
+      min-complexity: 15
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+      ignored-functions:
+        - ^Eventually$
+        - ^EventuallyWithOffset$
+        - ^ExpectWithOffset$
+        - ^console\.ExpectBatch$
+        - ^console\.RunCommand$
+    nolintlint:
+      require-explanation: false # don't require an explanation for nolint directives
+      require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+      allow-unused: false # report any unused nolint directives
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/ginkgo/v2
+        - github.com/onsi/gomega
+      checks:
+        - all
+        - "-QF1001" # exclude 'could apply De Morgan's law'
+        - "-QF1008" # exclude 'could remove embedded field "<field>" from selector'
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019: checks.SkipTestIfNoCPUManager'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - kubevirt.io/kubevirt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ test: generate
 	cd tests && go test -v -timeout 0 ./unittests/... $(UNITTEST_EXTRA_ARGS) 
 
 .PHONY: test-fmt
-test-fmt:
-	cd tests && go fmt ./...
+test-fmt: gofumpt
+	cd tests && gofumpt -w -extra .
 
 .PHONY: test-vet
 test-vet:
@@ -156,3 +156,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
+
+GOFUMPT ?= $(LOCALBIN)/gofumpt
+gofumpt: $(GOFUMPT)
+$(GOFUMPT): $(LOCALBIN)
+	test -s $(LOCALBIN)/gofumpt || GOBIN=$(LOCALBIN) go install mvdan.cc/gofumpt@latest

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBECONFORM_PACKAGE ?= github.com/yannh/kubeconform/cmd/kubeconform
 YQ_PACKAGE ?= github.com/mikefarah/yq/v4
 
 # Version of golangci-lint to install
-GOLANGCI_LINT_VERSION ?= v1.62.2
+GOLANGCI_LINT_VERSION ?= v2.2.2
 
 # Kubeconfig default value
 KUBECONFIG ?= ~/.kube/config

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -8,8 +8,8 @@
 #    * [openapi2jsonschema](https://github.com/instrumenta/openapi2jsonschema)
 #
 # Golang is provided to allow running other Makefile targets
-FROM quay.io/kubevirtci/golang:v20250211-4e3c019
-ENV GIMME_GO_VERSION=1.23.7
+FROM quay.io/kubevirtci/golang:v20250701-f32dbda
+ENV GIMME_GO_VERSION=1.24.5
 
 RUN dnf install -y make tar python3-pip ShellCheck && dnf clean all -y
 

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -72,28 +72,27 @@ var _ = Describe("Common instance types func tests", func() {
 	})
 
 	Context("VirtualMachine using a preference with resource requirements", func() {
-		var skipPreference = map[string]any{
+		skipPreference := map[string]any{
 			"legacy":                   nil,
 			"linux":                    nil,
 			"linux.efi":                nil,
 			"linux.virtiotransitional": nil,
 		}
 
-		clusterPreferencesWithRequirements :=
-			func() []instancetypev1beta1.VirtualMachineClusterPreference {
-				clusterPreferences, err := virtClient.VirtualMachineClusterPreference().List(context.Background(), metav1.ListOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(clusterPreferences.Items).ToNot(BeEmpty())
+		clusterPreferencesWithRequirements := func() []instancetypev1beta1.VirtualMachineClusterPreference {
+			clusterPreferences, listErr := virtClient.VirtualMachineClusterPreference().List(context.Background(), metav1.ListOptions{})
+			Expect(listErr).ToNot(HaveOccurred())
+			Expect(clusterPreferences.Items).ToNot(BeEmpty())
 
-				var completePreferences []instancetypev1beta1.VirtualMachineClusterPreference
-				for _, preference := range clusterPreferences.Items {
-					if _, ok := skipPreference[preference.Name]; !ok {
-						Expect(preference.Spec.Requirements).ToNot(BeNil())
-						completePreferences = append(completePreferences, preference)
-					}
+			var completePreferences []instancetypev1beta1.VirtualMachineClusterPreference
+			for _, preference := range clusterPreferences.Items {
+				if _, ok := skipPreference[preference.Name]; !ok {
+					Expect(preference.Spec.Requirements).ToNot(BeNil())
+					completePreferences = append(completePreferences, preference)
 				}
-				return completePreferences
 			}
+			return completePreferences
+		}
 
 		It("[test_id:10736] is rejected if it does not provide enough memory resources", func() {
 			createInstancetype(8, "tiny-instancetype-memory", "64M")

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/common-instancetypes/tests
 
-go 1.23.7
+go 1.24.4
 
 require (
 	github.com/onsi/ginkgo/v2 v2.23.0

--- a/tests/unittests/instancetype_test.go
+++ b/tests/unittests/instancetype_test.go
@@ -19,7 +19,6 @@ const (
 )
 
 var _ = Describe("Common instance types unit tests", func() {
-
 	skipLabels := map[string]bool{
 		"instancetype.kubevirt.io/arch":                         true,
 		"instancetype.kubevirt.io/os-type":                      true,
@@ -65,7 +64,6 @@ var _ = Describe("Common instance types unit tests", func() {
 				}
 			}
 		})
-
 	})
 
 	Context("VirtualMachineClusterInstanceType", func() {

--- a/tests/unittests/test_suite_test.go
+++ b/tests/unittests/test_suite_test.go
@@ -65,18 +65,17 @@ func FetchBundleResource[C clusterType](path string) ([]C, error) {
 }
 
 func fetchResourcesFromBundle() ([]instancetypev1beta1.VirtualMachineClusterInstancetype,
-	[]instancetypev1beta1.VirtualMachineClusterPreference, error) {
-	virtualMachineClusterInstancetypes, err :=
-		FetchBundleResource[instancetypev1beta1.VirtualMachineClusterInstancetype](clusterInstanceTypesBundlePath)
+	[]instancetypev1beta1.VirtualMachineClusterPreference, error,
+) {
+	instancetypes, err := FetchBundleResource[instancetypev1beta1.VirtualMachineClusterInstancetype](clusterInstanceTypesBundlePath)
 	if err != nil {
 		return nil, nil, err
 	}
-	virtualMachineClusterPreferences, err :=
-		FetchBundleResource[instancetypev1beta1.VirtualMachineClusterPreference](clusterPreferencesBundlePath)
+	preferences, err := FetchBundleResource[instancetypev1beta1.VirtualMachineClusterPreference](clusterPreferencesBundlePath)
 	if err != nil {
 		return nil, nil, err
 	}
-	return virtualMachineClusterInstancetypes, virtualMachineClusterPreferences, err
+	return instancetypes, preferences, err
 }
 
 // end of functions taken from SSP operator
@@ -91,8 +90,8 @@ func loadBundles() {
 var _ = BeforeSuite(func() {
 	loadBundles()
 
-	Expect(len(loadedVirtualMachineClusterInstanceTypes)).ToNot(BeZero())
-	Expect(len(loadedVirtualMachineClusterPreferences)).ToNot(BeZero())
+	Expect(loadedVirtualMachineClusterInstanceTypes).ToNot(BeEmpty())
+	Expect(loadedVirtualMachineClusterPreferences).ToNot(BeEmpty())
 })
 
 func TestUnit(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

- Use gofumpt to format test files. This is needed for a future golangci-lint update.
- Bump golangci-lint to v2.2.2 and fix new findings.
- Bump golang image and use go 1.24.5 in the builder image.
- Bump minimum go version in tests/go.mod to 1.24.4 to be in sync with tools/go.mod.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
