### PR TITLE
[release-1.3] feat(preference): Add Windows Server 2008

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,3 +332,5 @@ windows.2k22 | Microsoft Windows Server 2022
 windows.2k22.virtio | Microsoft Windows Server 2022 (virtio)
 windows.2k25 | Microsoft Windows Server 2025
 windows.2k25.virtio | Microsoft Windows Server 2025 (virtio)
+windows.2k8 | Microsoft Windows Server 2008/2008 R2
+windows.2k8.virtio | Microsoft Windows Server 2008/2008 R2 (virtio)

--- a/preferences/windows/2k8/kustomization.yaml
+++ b/preferences/windows/2k8/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+components:
+  - ./metadata
+  - ./requirements
+  - ../../components/interfacemodel-e1000
+
+nameSuffix: .2k8

--- a/preferences/windows/2k8/metadata/kustomization.yaml
+++ b/preferences/windows/2k8/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/2k8/metadata/metadata.yaml
+++ b/preferences/windows/2k8/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2008/2008 R2"

--- a/preferences/windows/2k8/requirements/kustomization.yaml
+++ b/preferences/windows/2k8/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/2k8/requirements/requirements.yaml
+++ b/preferences/windows/2k8/requirements/requirements.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+spec:
+  # https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/cc755116(v=ws.10)#system-requirements
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 512Mi

--- a/preferences/windows/2k8_virtio/kustomization.yaml
+++ b/preferences/windows/2k8_virtio/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../2k8
+
+components:
+  - ./metadata
+  - ../../components/diskbus-virtio-blk
+  - ../../components/interfacemodel-virtio-net
+  - ../../components/tablet-virtio
+
+nameSuffix: .virtio

--- a/preferences/windows/2k8_virtio/metadata/kustomization.yaml
+++ b/preferences/windows/2k8_virtio/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/2k8_virtio/metadata/metadata.yaml
+++ b/preferences/windows/2k8_virtio/metadata/metadata.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Microsoft Windows Server 2008/2008 R2 (virtio)"

--- a/preferences/windows/kustomization.yaml
+++ b/preferences/windows/kustomization.yaml
@@ -3,6 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ./2k8
+  - ./2k8_virtio
   - ./2k16
   - ./2k16_virtio
   - ./2k19

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -260,12 +260,12 @@ var _ = Describe("Common instance types func tests", func() {
 				map[string]string{"amd64": "debian", "arm64": "debian"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
 		)
 
-		DescribeTable("a Windows guest with", func(containerDisk string, preferences map[string]string, testFns []testFn) {
+		DescribeTable("a Windows guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
 			preference, hasArch := preferences[preferenceArch]
 			if !hasArch {
 				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
 			}
-			vm = randomVM(&v1.InstancetypeMatcher{Name: "u1.2xmedium"}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
+			vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
 			addContainerDisk(vm, containerDisk)
 			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -274,19 +274,34 @@ var _ = Describe("Common instance types func tests", func() {
 				testFn(virtClient, vm.Name)
 			}
 		},
-			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, map[string]string{"amd64": "windows.11"},
-				[]testFn{expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 10", windows10ContainerDisk, map[string]string{"amd64": "windows.10.virtio"},
+			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.11"}, []testFn{expectSSHToRunCommandOnWindows}),
+			Entry("[test_id:????] Windows 10", windows10ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.10.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows 11", windows11ContainerDisk, map[string]string{"amd64": "windows.11.virtio"},
+			Entry("[test_id:????] Windows 11", windows11ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.11.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, map[string]string{"amd64": "windows.2k16.virtio"},
+			Entry("[test_id:????] Windows Server 2008 i386", windows2k8I386ContainerDisk, "u1.nano",
+				map[string]string{"amd64": "windows.2k8.virtio"},
+				[]testFn{expectGuestAgentToBeConnected}),
+			Entry("[test_id:????] Windows Server 2008 amd64", windows2k8Amd64ContainerDisk, "u1.nano",
+				map[string]string{"amd64": "windows.2k8.virtio"},
+				[]testFn{expectGuestAgentToBeConnected}),
+			Entry("[test_id:????] Windows Server 2008 R2", windows2k8R2ContainerDisk, "u1.nano",
+				map[string]string{"amd64": "windows.2k8.virtio"},
+				[]testFn{expectGuestAgentToBeConnected}),
+			Entry("[test_id:????] Windows Server 2016", windows2k16ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k16.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, map[string]string{"amd64": "windows.2k19.virtio"},
+			Entry("[test_id:????] Windows Server 2019", windows2k19ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k19.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, map[string]string{"amd64": "windows.2k22.virtio"},
+			Entry("[test_id:????] Windows Server 2022", windows2k22ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k22.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
-			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, map[string]string{"amd64": "windows.2k25.virtio"},
+			Entry("[test_id:????] Windows Server 2025", windows2k25ContainerDisk, "u1.2xmedium",
+				map[string]string{"amd64": "windows.2k25.virtio"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnWindows}),
 		)
 	})

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -47,6 +47,9 @@ const (
 	defaultValidationOsContainerDisk       = "registry:5000/validation-os-container-disk:latest"
 	defaultWindows10ContainerDisk          = "registry:5000/windows10-container-disk:latest"
 	defaultWindows11ContainerDisk          = "registry:5000/windows11-container-disk:latest"
+	defaultWindows2k8I386ContainerDisk     = "registry:5000/windows2k8-container-disk:i386"
+	defaultWindows2k8Amd64ContainerDisk    = "registry:5000/windows2k8-container-disk:amd64"
+	defaultWindows2k8R2ContainerDisk       = "registry:5000/windows2k8r2-container-disk:latest"
 	defaultWindows2k16ContainerDisk        = "registry:5000/windows2k16-container-disk:latest"
 	defaultWindows2k19ContainerDisk        = "registry:5000/windows2k19-container-disk:latest"
 	defaultWindows2k22ContainerDisk        = "registry:5000/windows2k22-container-disk:latest"
@@ -76,6 +79,9 @@ var (
 	validationOsContainerDisk       string
 	windows10ContainerDisk          string
 	windows11ContainerDisk          string
+	windows2k8I386ContainerDisk     string
+	windows2k8Amd64ContainerDisk    string
+	windows2k8R2ContainerDisk       string
 	windows2k16ContainerDisk        string
 	windows2k19ContainerDisk        string
 	windows2k22ContainerDisk        string
@@ -144,6 +150,12 @@ func init() {
 		defaultWindows10ContainerDisk, "Windows 10 container disk used by functional tests")
 	flag.StringVar(&windows11ContainerDisk, "windows-11-container-disk",
 		defaultWindows11ContainerDisk, "Windows 11 container disk used by functional tests")
+	flag.StringVar(&windows2k8I386ContainerDisk, "windows-2k8-i386-container-disk",
+		defaultWindows2k8I386ContainerDisk, "Windows Server 2008 i368 container disk used by functional tests")
+	flag.StringVar(&windows2k8Amd64ContainerDisk, "windows-2k8-amd64-container-disk",
+		defaultWindows2k8Amd64ContainerDisk, "Windows Server 2008 amd64 container disk used by functional tests")
+	flag.StringVar(&windows2k8R2ContainerDisk, "windows-2k8r2-container-disk",
+		defaultWindows2k8R2ContainerDisk, "Windows Server 2008 R2 container disk used by functional tests")
 	flag.StringVar(&windows2k16ContainerDisk, "windows-2k16-container-disk",
 		defaultWindows2k16ContainerDisk, "Windows Server 2016 container disk used by functional tests")
 	flag.StringVar(&windows2k19ContainerDisk, "windows-2k19-container-disk",


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/common-instancetypes/pull/385

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-66806](https://issues.redhat.com/browse/CNV-66806)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `windows.2k8` and windows.2k8.virtio` preferences for Windows Server 2008
```
