### PR TITLE
feat: add cpu.maxSockets to cx instance types

### DIFF
--- a/instancetypes/cx/1/sizes.yaml
+++ b/instancetypes/cx/1/sizes.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   cpu:
     guest: 8
+    maxSockets: 8
   memory:
     guest: "16Gi"
     hugepages:
@@ -28,6 +29,7 @@ metadata:
 spec:
   cpu:
     guest: 16
+    maxSockets: 16
   memory:
     guest: "32Gi"
     hugepages:
@@ -45,6 +47,7 @@ metadata:
 spec:
   cpu:
     guest: 32
+    maxSockets: 32
   memory:
     guest: "64Gi"
     hugepages:
@@ -62,6 +65,7 @@ metadata:
 spec:
   cpu:
     guest: 2
+    maxSockets: 2
   memory:
     guest: "4Gi"
     hugepages:
@@ -79,6 +83,7 @@ metadata:
 spec:
   cpu:
     guest: 1
+    maxSockets: 1
   memory:
     guest: "2Gi"
     hugepages:
@@ -96,6 +101,7 @@ metadata:
 spec:
   cpu:
     guest: 4
+    maxSockets: 4
   memory:
     guest: "8Gi"
     hugepages:
@@ -113,6 +119,7 @@ metadata:
 spec:
   cpu:
     guest: 8
+    maxSockets: 8
   memory:
     guest: "16Gi"
     hugepages:
@@ -130,6 +137,7 @@ metadata:
 spec:
   cpu:
     guest: 16
+    maxSockets: 16
   memory:
     guest: "32Gi"
     hugepages:
@@ -147,6 +155,7 @@ metadata:
 spec:
   cpu:
     guest: 32
+    maxSockets: 32
   memory:
     guest: "64Gi"
     hugepages:
@@ -164,6 +173,7 @@ metadata:
 spec:
   cpu:
     guest: 2
+    maxSockets: 2
   memory:
     guest: "4Gi"
     hugepages:
@@ -181,6 +191,7 @@ metadata:
 spec:
   cpu:
     guest: 1
+    maxSockets: 1
   memory:
     guest: "2Gi"
     hugepages:
@@ -198,6 +209,7 @@ metadata:
 spec:
   cpu:
     guest: 4
+    maxSockets: 4
   memory:
     guest: "8Gi"
     hugepages:


### PR DESCRIPTION
**What this PR does / why we need it**:
feat: add cpu.maxSockets to cx instance types

Adding cpu.maxSockets will disable hotplugging. Hotplugging might cause problems (requesting more cpus, that KVM might not handle (error: Number of hotpluggable cpus requested exceeds the recommended cpus supported by KVM)).

https://issues.redhat.com/browse/CNV-66903

**Release note**:
```release-note
feat: add cpu.maxSockets to cx instance types
```
