### PR TITLE
Add eLxr VirtualMachinePreference

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ centos.stream9.desktop | CentOS Stream 9
 centos.stream9.dpdk | CentOS Stream 9
 cirros | Cirros
 debian | Debian
+elxr | eLxr Linux (amd64)
+elxr.arm64 | eLxr Linux (arm64)
 fedora | Fedora (amd64)
 fedora.arm64 | Fedora (arm64)
 fedora.s390x | Fedora (s390x)

--- a/preferences/elxr/amd64/kustomization.yaml
+++ b/preferences/elxr/amd64/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../linux-efi
+
+components:
+  - ./metadata
+  - ../requirements
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: elxr
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: elxr

--- a/preferences/elxr/amd64/metadata/kustomization.yaml
+++ b/preferences/elxr/amd64/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/elxr/amd64/metadata/metadata.yaml
+++ b/preferences/elxr/amd64/metadata/metadata.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,elxr"
+    iconClass: "icon-debian"
+    openshift.io/display-name: "eLxr Linux (amd64)"
+  labels:
+    instancetype.kubevirt.io/arch: "amd64"

--- a/preferences/elxr/arm64/kustomization.yaml
+++ b/preferences/elxr/arm64/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../linux-efi
+
+components:
+  - ./metadata
+  - ../requirements
+
+patches:
+  - target:
+      kind: VirtualMachinePreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: elxr.arm64
+  - target:
+      kind: VirtualMachineClusterPreference
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: elxr.arm64

--- a/preferences/elxr/arm64/metadata/kustomization.yaml
+++ b/preferences/elxr/arm64/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/elxr/arm64/metadata/metadata.yaml
+++ b/preferences/elxr/arm64/metadata/metadata.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,elxr"
+    iconClass: "icon-debian"
+    openshift.io/display-name: "eLxr Linux (arm64)"
+  labels:
+    instancetype.kubevirt.io/arch: "arm64"

--- a/preferences/elxr/kustomization.yaml
+++ b/preferences/elxr/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./amd64
+  - ./arm64

--- a/preferences/elxr/requirements/kustomization.yaml
+++ b/preferences/elxr/requirements/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./requirements.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/elxr/requirements/requirements.yaml
+++ b/preferences/elxr/requirements/requirements.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: requirements
+  labels:
+    instancetype.kubevirt.io/required-cpu: "1"
+    instancetype.kubevirt.io/required-memory: "512Mi"
+spec:
+  # https://www.elxr.dev
+  # eLxr is based on Debian, minimum requirements align with Debian
+  # https://www.debian.org/releases/stable/amd64/ch03s04.en.html
+  requirements:
+    cpu:
+      guest: 1
+    memory:
+      guest: 512Mi

--- a/preferences/kustomization.yaml
+++ b/preferences/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - ./linux-virtio-transitional
   - ./legacy
   - ./debian
+  - ./elxr
   - ./oraclelinux

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -264,6 +264,8 @@ var _ = Describe("Common instance types func tests", func() {
 				map[string]string{"amd64": "debian", "arm64": "debian"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
 			Entry("[test_id:TODO] Debian 13", debian13ContainerDisk, "u1.small",
 				map[string]string{"amd64": "debian", "arm64": "debian"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
+			Entry("[test_id:TODO] eLxr", elxrContainerDisk, "u1.small",
+				map[string]string{"amd64": "elxr", "arm64": "elxr.arm64"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
 		)
 
 		DescribeTable("a Windows guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {

--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -39,6 +39,7 @@ const (
 	defaultUbuntu2404ContainerDisk         = "quay.io/containerdisks/ubuntu:24.04"
 	defaultOpenSUSETumbleweedContainerDisk = "quay.io/containerdisks/opensuse-tumbleweed:1.0.0"
 	defaultOpenSUSELeap15ContainerDisk     = "quay.io/containerdisks/opensuse-leap:15.6"
+	defaultElxrContainerDisk               = "registry:5000/elxr-container-disk:latest"
 	defaultDebian11ContainerDisk           = "quay.io/containerdisks/debian:11"
 	defaultDebian12ContainerDisk           = "quay.io/containerdisks/debian:12"
 	defaultDebian13ContainerDisk           = "quay.io/containerdisks/debian:13"
@@ -104,6 +105,7 @@ var (
 	sles15SP5ContainerDisk          string
 	sles15SP6ContainerDisk          string
 	sles15SP7ContainerDisk          string
+	elxrContainerDisk               string
 	debian11ContainerDisk           string
 	debian12ContainerDisk           string
 	debian13ContainerDisk           string
@@ -150,6 +152,8 @@ func init() {
 		defaultOpenSUSETumbleweedContainerDisk, "OpenSUSE Tumbleweed container disk used by functional tests")
 	flag.StringVar(&openSUSELeap15ContainerDisk, "opensuse-leap-container-disk",
 		defaultOpenSUSELeap15ContainerDisk, "OpenSUSE Leap container disk used by functional tests")
+	flag.StringVar(&elxrContainerDisk, "elxr-container-disk",
+		defaultElxrContainerDisk, "eLxr container disk used by functional tests")
 	flag.StringVar(&debian11ContainerDisk, "debian-11-container-disk",
 		defaultDebian11ContainerDisk, "Debian 11 container disk used by functional tests")
 	flag.StringVar(&debian12ContainerDisk, "debian-12-container-disk",


### PR DESCRIPTION
What this PR does / why we need it:

Adds a new VirtualMachinePreference for eLxr, a Debian-based Linux distribution by Wind River designed for cloud-native and edge computing workloads.

The eLxr preference inherits from linux-efi since eLxr uses UEFI boot and virtio devices. Minimum requirements are 1 CPU and 512Mi memory, aligned with Debian's base requirements.

Changes:

- Added preferences/elxr/ with amd64 and arm64 architecture support
- Registered elxr in preferences/kustomization.yaml
- Updated README.md via make generate and make readme
- Added functional tests for the new preference

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

- kubectl kustomize preferences/elxr generates correct resources
- kubectl kustomize preferences/ builds all preferences successfully
- Applied to a live K8s cluster — both VirtualMachineClusterPreference and VirtualMachinePreference created successfully

Release note:

Add eLxr Linux VirtualMachinePreference for running eLxr Linux guests with amd64 and arm64 architecture support