### PR TITLE
Add preferredVideoType virtio to Windows virtio preferences

### DIFF
--- a/preferences/components/videotype-virtio/kustomization.yaml
+++ b/preferences/components/videotype-virtio/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./videotype-virtio.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./videotype-virtio.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/videotype-virtio/videotype-virtio.yaml
+++ b/preferences/components/videotype-virtio/videotype-virtio.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: videotype-virtio
+spec:
+  devices:
+    preferredVideoType: virtio

--- a/preferences/windows/10_virtio/kustomization.yaml
+++ b/preferences/windows/10_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/11_virtio/kustomization.yaml
+++ b/preferences/windows/11_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k12_virtio/kustomization.yaml
+++ b/preferences/windows/2k12_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k16_virtio/kustomization.yaml
+++ b/preferences/windows/2k16_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k19_virtio/kustomization.yaml
+++ b/preferences/windows/2k19_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k22_virtio/kustomization.yaml
+++ b/preferences/windows/2k22_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k25_virtio/kustomization.yaml
+++ b/preferences/windows/2k25_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/2k8_virtio/kustomization.yaml
+++ b/preferences/windows/2k8_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio

--- a/preferences/windows/7_virtio/kustomization.yaml
+++ b/preferences/windows/7_virtio/kustomization.yaml
@@ -10,5 +10,6 @@ components:
   - ../../components/diskbus-virtio-blk
   - ../../components/interfacemodel-virtio-net
   - ../../components/tablet-virtio
+  - ../../components/videotype-virtio
 
 nameSuffix: .virtio


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a new `videotype-virtio` kustomize component that sets `preferredVideoType: virtio` and include it in all Windows virtio preference variants.

This complements the existing virtio device preferences (disk bus, network interface, tablet input) so that VMs
using these preferences also get a virtio-gpu video device instead of the default VGA/Bochs.

**References**:

- Jira: https://issues.redhat.com/browse/CNV-82157
- Upstream KubeVirt PR adding `PreferredVideoType` to DevicePreferences: https://github.com/kubevirt/kubevirt/pull/16812

**Release note**:
```release-note
Set preferredVideoType to virtio for Windows virtio preferences
```