### PR TITLE
fix(test): Add KUBEVIRT_PROVIDER to `make cluster/kubevirt-up` and fix formatting issues

### DIFF
--- a/scripts/kubevirt.sh
+++ b/scripts/kubevirt.sh
@@ -18,6 +18,7 @@ set -ex
 
 export KUBEVIRT_MEMORY_SIZE="${KUBEVIRT_MEMORY_SIZE:-16G}"
 export KUBEVIRT_TAG="${KUBEVIRT_TAG:-main}"
+export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.36}"
 
 _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _kubectl="${_base_dir}/_kubevirt/kubevirtci/cluster-up/kubectl.sh"

--- a/scripts/kubevirtci.sh
+++ b/scripts/kubevirtci.sh
@@ -19,7 +19,8 @@ set -ex
 export KUBEVIRT_MEMORY_SIZE="${KUBEVIRT_MEMORY_SIZE:-16G}"
 export KUBEVIRT_DEPLOY_CDI="true"
 export KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-main}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://raw.githubusercontent.com/kubevirt/kubevirt/"${KUBEVIRT_VERSION}"/kubevirtci/cluster-up/version.txt)}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2606122341-dc57311b}
+export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.36}"
 
 _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _cluster_up_dir="${_base_dir}/_cluster-up"

--- a/tests/functests/instancetype_test.go
+++ b/tests/functests/instancetype_test.go
@@ -109,7 +109,8 @@ var _ = Describe("Common instance types func tests", func() {
 							"failure checking preference requirements: "+
 							"insufficient Memory resources of 64M provided by instance type, preference requires %s",
 						preference.Spec.Requirements.Memory.Guest.String(),
-					)))
+					),
+				))
 			}
 		})
 
@@ -183,21 +184,22 @@ var _ = Describe("Common instance types func tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		DescribeTable("a Linux guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
-			preference, hasArch := preferences[preferenceArch]
-			if !hasArch {
-				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
-			}
-			vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
-			addContainerDisk(vm, containerDisk)
-			addCloudInitWithAuthorizedKey(vm, privKey)
-			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			expectVMToBeReady(virtClient, vm.Name, defaultVMReadyTimeout)
-			for _, testFn := range testFns {
-				testFn(virtClient, vm.Name)
-			}
-		},
+		DescribeTable(
+			"a Linux guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
+				preference, hasArch := preferences[preferenceArch]
+				if !hasArch {
+					Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
+				}
+				vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
+				addContainerDisk(vm, containerDisk)
+				addCloudInitWithAuthorizedKey(vm, privKey)
+				vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				expectVMToBeReady(virtClient, vm.Name, defaultVMReadyTimeout)
+				for _, testFn := range testFns {
+					testFn(virtClient, vm.Name)
+				}
+			},
 			Entry("[test_id:10738] Fedora", fedoraContainerDisk, "u1.small",
 				map[string]string{"amd64": "fedora", "arm64": "fedora.arm64", "s390x": "fedora.s390x"},
 				[]testFn{expectGuestAgentToBeConnected, expectSSHToRunCommandOnLinux("fedora")}),
@@ -266,20 +268,21 @@ var _ = Describe("Common instance types func tests", func() {
 				map[string]string{"amd64": "debian", "arm64": "debian"}, []testFn{expectSSHToRunCommandOnLinux("debian")}),
 		)
 
-		DescribeTable("a Windows guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
-			preference, hasArch := preferences[preferenceArch]
-			if !hasArch {
-				Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
-			}
-			vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
-			addContainerDisk(vm, containerDisk)
-			vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			expectVMToBeReady(virtClient, vm.Name, windowsReadyTimeout)
-			for _, testFn := range testFns {
-				testFn(virtClient, vm.Name)
-			}
-		},
+		DescribeTable(
+			"a Windows guest with", func(containerDisk, instancetype string, preferences map[string]string, testFns []testFn) {
+				preference, hasArch := preferences[preferenceArch]
+				if !hasArch {
+					Skip(fmt.Sprintf("skipping as no preference provided for arch %s", preferenceArch))
+				}
+				vm = randomVM(&v1.InstancetypeMatcher{Name: instancetype}, &v1.PreferenceMatcher{Name: preference}, v1.RunStrategyAlways)
+				addContainerDisk(vm, containerDisk)
+				vm, err = virtClient.VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				expectVMToBeReady(virtClient, vm.Name, windowsReadyTimeout)
+				for _, testFn := range testFns {
+					testFn(virtClient, vm.Name)
+				}
+			},
 			Entry("[test_id:10739] Validation OS", validationOsContainerDisk, "u1.2xmedium",
 				map[string]string{"amd64": "windows.11"}, []testFn{expectSSHToRunCommandOnWindows}),
 			Entry("[test_id:????] Windows 7", windows7ContainerDisk, "u1.small",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The current default `KUBEVIRT_PROVIDER` is 1.34, due to the following issue; kubevirt/kubevirt#17460, CI is broken.
It adds `KUBEVIRT_PROVIDER=k8s-1.36` which fixes the issue.

Moreover, The newer version of gofumpt (v0.10.0) introduced stricter formatting rules, causing the CI failure. It fixes these issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
