### PR TITLE
Bump Go to 1.26.4 and golangci-lint to v2.12.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,6 +104,9 @@ linters:
       - std-error-handling
     rules:
       - linters:
+          - goconst
+        path: _test\.go
+      - linters:
           - staticcheck
         text: 'SA1019: checks.SkipTestIfNoCPUManager'
     paths:

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ $(YQ): $(LOCALBIN)
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 golangci-lint: $(GOLANGCI_LINT)
 $(GOLANGCI_LINT): $(LOCALBIN)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
 
 GOFUMPT ?= $(LOCALBIN)/gofumpt
 gofumpt: $(GOFUMPT)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ KUBECONFORM_PACKAGE ?= github.com/yannh/kubeconform/cmd/kubeconform
 YQ_PACKAGE ?= github.com/mikefarah/yq/v4
 
 # Version of golangci-lint to install
-GOLANGCI_LINT_VERSION ?= v2.2.2
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # Kubeconfig default value
 KUBECONFIG ?= ~/.kube/config

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -9,7 +9,7 @@
 #
 # Golang is provided to allow running other Makefile targets
 FROM quay.io/kubevirtci/golang:v20251022-6eb3ab1
-ENV GIMME_GO_VERSION=1.24.9
+ENV GIMME_GO_VERSION=1.26.4
 
 RUN dnf install -y make tar python3-pip ShellCheck && dnf clean all -y
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the builder image Go version from 1.24.9 to 1.26.4 and golangci-lint from v2.2.2 to v2.12.2. The current versions are too old to handle Go 1.26 code required by `tools/go.mod`, causing the v1.7.0 release workflow to fail with:

```
panic: file requires newer Go version go1.26 (application built with go1.24)
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The builder image will also need to be rebuilt and pushed after this merges, and `COMMON_INSTANCETYPES_IMAGE_TAG` in the Makefile updated to reference the new image.

**Release note**:
```release-note
NONE
```