### PR TITLE
Update builder image tag to v20260619-7a6447db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ export KUBEVIRT_TAG = main
 # Use the COMMON_INSTANCETYPES_CRI env variable to control if the following targets are executed within a container.
 # Supported runtimes are docker and podman. By default targets run directly on the host.
 export COMMON_INSTANCETYPES_IMAGE = quay.io/kubevirtci/common-instancetypes-builder
-export COMMON_INSTANCETYPES_IMAGE_TAG = v20250724-df773ff
+export COMMON_INSTANCETYPES_IMAGE_TAG = v20260619-7a6447db
 
 # Containerdisk image and tag to use for Validation OS functional tests
 export VALIDATION_OS_IMAGE = quay.io/kubevirtci/validation-os-container-disk


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the builder image tag to `v20260619-7a6447db` which includes Go 1.26.4 and golangci-lint v2.12.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```