### PR TITLE
Improve release docs and add Claude release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: release
+description: Guide through the common-instancetypes release process
+user_invocable: true
+arguments:
+  - name: version
+    description: "Release version (e.g. v1.7.0)"
+    required: true
+---
+
+# Common Instancetypes Release
+
+Guide the user through the release process for common-instancetypes version `$ARGUMENTS.version`.
+
+## Instructions
+
+1. Read `docs/release.md` for the full checklist and context.
+2. Parse the version from `$ARGUMENTS.version` to determine:
+   - `Y` — the minor version (e.g. `7` for `v1.7.0`)
+   - Release branch: `release-1.${Y}`
+   - Previous release branch: `release-1.${Y-1}`
+   - Corresponding kubevirt release branch for the periodic: `release-1.${Y+1}`
+3. Run pre-flight checks:
+   - Compare `GIMME_GO_VERSION` in `image/Dockerfile` with the Go version in `tools/go.mod` — warn if they're incompatible.
+   - Check that `GOLANGCI_LINT_VERSION` in the `Makefile` is recent enough to support the project's Go version.
+   - Check that `COMMON_INSTANCETYPES_IMAGE_TAG` in the `Makefile` references an image built with the correct Go version.
+4. Check current state:
+   - Does `release-1.${Y}` branch already exist? (`git branch -a | grep release-1.${Y}`)
+   - Does `v1.${Y}.0` tag already exist? (`git tag -l v1.${Y}.0`)
+   - Does a `v1.${Y}.0` milestone exist? (`gh api repos/kubevirt/common-instancetypes/milestones`)
+   - Does a `v1.${Y+1}.0` milestone exist?
+   - Check project-infra for existing release jobs and periodics.
+5. Walk through each checklist item interactively, confirming with the user before taking actions that push to remote repositories or create PRs.
+6. For the project-infra steps (presubmit jobs, periodics), the files live in:
+   - `../project-infra/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/`
+   - Copy `common-instancetypes-presubmits.yaml` to `common-instancetypes-1.${Y}.yaml`, updating branch references to `release-1.${Y}` and appending `-1.${Y}` to all job names.
+   - Update `COMMON_INSTANCETYPES_BRANCH` in the main `periodic-update-common-instancetypes-bundles` to `release-1.${Y}`.
+   - Add `periodic-update-common-instancetypes-bundles-1.${Y-1}` to sync `release-1.${Y-1}` with kubevirt `release-1.${Y+1}` if that kubevirt branch exists.
+7. After completing steps, update the milestone description with the checklist and PR references.
+8. Use `origin-ssh` (not `origin`) for push operations as HTTPS auth is not configured.
+
+## Recovery
+
+If the release workflow fails:
+1. Diagnose the failure from the GitHub Actions logs.
+2. Fix on `main`, cherry-pick to `release-1.${Y}`.
+3. Delete and re-push the tag: `git push origin-ssh :refs/tags/v1.${Y}.0 && git tag -d v1.${Y}.0 && git tag v1.${Y}.0 && git push origin-ssh v1.${Y}.0`

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,8 +1,18 @@
 # Release Process
 
-The common-instancetypes project releases after the `beta.0` release of `kubevirt/kubevirt`:
+The common-instancetypes project releases before the code freeze of `kubevirt/kubevirt`:
 
 <https://github.com/kubevirt/sig-release/blob/main/releases/release-checklist.md#kubevirt-pre-release-checklist>
+
+## Pre-flight checks
+
+Before starting the release, verify:
+
+* The Go version in `image/Dockerfile` (`GIMME_GO_VERSION`) is compatible
+  with `tools/go.mod`. If not, bump it, rebuild the builder image, and update
+  `COMMON_INSTANCETYPES_IMAGE_TAG` in the `Makefile`.
+* The `golangci-lint` version in the `Makefile` (`GOLANGCI_LINT_VERSION`)
+  supports the Go version used by the project.
 
 ## Checklist
 
@@ -11,16 +21,26 @@ The common-instancetypes project releases after the `beta.0` release of `kubevir
 * [ ] Ensure the [release
 workflow](https://github.com/kubevirt/common-instancetypes/blob/67e413352b081deaec3ec504912947836532a731/.github/workflows/release.yaml)
 runs and succeeds
-* [ ] Copy and rename main pre-submit jobs definitions to a new release specific
-file
-* [ ] Update `periodic-update-common-instancetypes-bundles` periodic to sync
-latest release with `kubevirt/kubevirt` `main`
+* [ ] Copy and rename main pre-submit job definitions to a new release specific
+file in
+[`kubevirt/project-infra`](https://github.com/kubevirt/project-infra/tree/main/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes)
+* [ ] Update `periodic-update-common-instancetypes-bundles` in
+[`common-instancetypes-periodics.yaml`](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml)
+to sync latest release with `kubevirt/kubevirt` `main`
 * [ ] Once `periodic-update-common-instancetypes-bundles` runs work to merge
 new release into `kubevirt/kubevirt` `main`
-* [ ] Introduce `periodic-update-common-instancetypes-bundles-1.${Y}` once a
+* [ ] Introduce `periodic-update-common-instancetypes-bundles-1.${Y-1}` once a
 new version of `kubevirt/kubevirt` is cut to keep the corresponding `release`
-branch sync'd with our `releease-1.${Y}` branch
-* [ ] Create a `v1.{Y+1}.0` milestone for the new release cycle and copy this
+branch sync'd with our `release-1.${Y-1}` branch
+* [ ] Create a `v1.${Y+1}.0` milestone for the new release cycle and copy this
 checklist into description
 * [ ] Update milestone once release schedule for the corresponding
 `kubevirt/kubevirt` release agreed on
+
+## Recovery
+
+If the release workflow fails after tagging:
+
+1. Fix the issue on `main` and cherry-pick to `release-1.${Y}`
+2. Delete the remote tag: `git push origin :refs/tags/v1.${Y}.0`
+3. Re-tag on the updated branch and push: `git tag v1.${Y}.0 && git push origin v1.${Y}.0`


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves `docs/release.md` based on lessons learned during the v1.7.0 release:
- Corrects timing to "before code freeze" (was "after beta.0")
- Adds pre-flight checks for Go and golangci-lint version compatibility
- Adds links to the project-infra file locations for CI job definitions
- Adds recovery steps for failed release workflows
- Fixes typo (`releease` → `release`)
- Fixes step 7 to reference `release-1.${Y-1}` (the previous release branch)

Also adds a Claude skill (`/release`) to guide users through the release process interactively.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```