### PR TITLE
functests: add --test-namespace flag

### DIFF
--- a/tests/functests/test_suite_test.go
+++ b/tests/functests/test_suite_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	testNamespace = "common-instancetype-functest"
+	defaultTestNamespace = "common-instancetype-functest"
 
 	defaultAlmaLinux9ContainerDisk         = "quay.io/containerdisks/almalinux:9"
 	defaultAlmaLinux10ContainerDisk        = "quay.io/containerdisks/almalinux:10"
@@ -118,8 +118,10 @@ var (
 	ol8ContainerDisk                string
 	ol9ContainerDisk                string
 
-	preferenceArch      string
-	windowsReadyTimeout time.Duration
+	preferenceArch           string
+	windowsReadyTimeout      time.Duration
+	testNamespace            string
+	testNamespacePreexisting bool
 )
 
 //nolint:gochecknoinits
@@ -215,6 +217,8 @@ func init() {
 	flag.StringVar(&preferenceArch, "preference-arch", "", "Architecture to test preferences for")
 	flag.DurationVar(&windowsReadyTimeout, "windows-ready-timeout",
 		defaultVMReadyTimeout, "Duration after Windows VM will timeout")
+	flag.StringVar(&testNamespace, "test-namespace", defaultTestNamespace,
+		"Namespace used for functional tests")
 }
 
 func getClusterArch(virtClient kubecli.KubevirtClient) string {
@@ -252,19 +256,29 @@ var _ = BeforeSuite(func() {
 		preferenceArch = getClusterArch(virtClient)
 	}
 
-	namespaceObj := &core.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: testNamespace,
-		},
+	_, err = virtClient.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		testNamespacePreexisting = false
+		namespaceObj := &core.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		_, err = virtClient.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	} else {
+		Expect(err).ToNot(HaveOccurred())
+		testNamespacePreexisting = true
 	}
-	_, err = virtClient.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
-	Expect(err).ToNot(And(HaveOccurred(), Not(MatchError(errors.IsAlreadyExists, "errors.IsAlreadyExists"))))
 
 	checkDeployedResources()
 })
 
 var _ = AfterSuite(func() {
-	// Clean up namespaced resources
+	if testNamespacePreexisting {
+		return
+	}
+	// Clean up namespaced resources created for this test run
 	err := virtClient.CoreV1().Namespaces().Delete(context.TODO(), testNamespace, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary

Add a `--test-namespace` command-line flag to `functests.test` so downstream CI can run functional tests in a namespace other than the hardcoded `common-instancetype-functest`.

Default behavior is unchanged when the flag is omitted.

## Motivation

CNV QE runs common-instancetypes tier1 tests in a namespace shared with Windows DataSource deployment (`validation-os-images`). Today the test binary always creates and uses `common-instancetype-functest`, while our wrapper scripts prepare resources in a different namespace.

## Changes

**File:** `tests/functests/test_suite_test.go`

* Replace the `testNamespace` constant with a `--test-namespace` flag (default: `common-instancetype-functest`)
* `instancetype_test.go` in the same package continues to use `testNamespace` unchanged
* **BeforeSuite:** fail fast on namespace lookup errors other than `NotFound`
* **AfterSuite:** skip namespace deletion when the namespace already existed before `BeforeSuite` (safe for shared/pre-provisioned namespaces)

## Downstream usage

CNV QE `run.sh` passes the flag only when the rebuilt test binary supports it:

    --test-namespace="${TEST_NAMESPACE}"

## Testing

* `go build ./functests/...` passes locally
* CI functests with default namespace
* CI functests with `--test-namespace=custom-ns`

Supersedes #529 (closed due to broken branch history after force-push).

/cc @lyarwood

```release-note
Added `--test-namespace` flag to functests so downstream CI can run functional tests in a pre-provisioned or shared namespace instead of the default `common-instancetype-functest`. When the namespace already exists before the suite starts, AfterSuite no longer deletes it.
```

Made with [Cursor](https://cursor.com)