### PR TITLE
preferences: Add hyperv panic device to Windows preferences

### DIFF
--- a/preferences/components/panic-model-hyperv/kustomization.yaml
+++ b/preferences/components/panic-model-hyperv/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./panic-model-hyperv.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./panic-model-hyperv.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/panic-model-hyperv/panic-model-hyperv.yaml
+++ b/preferences/components/panic-model-hyperv/panic-model-hyperv.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: panic-model-hyperv
+spec:
+  devices:
+    preferredPanicDeviceModel: hyperv

--- a/preferences/windows/base/kustomization.yaml
+++ b/preferences/windows/base/kustomization.yaml
@@ -11,6 +11,7 @@ components:
   - ../../components/cpu-topology-sockets
   - ../../components/diskbus-sata
   - ../../components/interfacemodel-e1000e
+  - ../../components/panic-model-hyperv
   - ../../components/tablet-usb
   # Setting termination grace period of 1 hour (3600 secs), because Windows
   # can take longer to shut down or reboot when updates or other changes


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `panic-model-hyperv` kustomize component that sets `preferredPanicDeviceModel: hyperv` and includes it in the Windows base preferences. This enables Hyper-V crash notification (hv-crash) detection for all Windows VMs using these preferences.

The `hyperv` model is preferred over `pvpanic` for Windows guests as it uses native Hyper-V MSRs rather than requiring a separate PCI/ISA device and guest driver. Modern Windows guests with Hyper-V enlightenments already enabled will use it natively, while older guests that predate Hyper-V will harmlessly ignore it.

**Which issue(s) this PR fixes**:

Depends on kubevirt/kubevirt#18314 which fixes `PreferredPanicDeviceModel` to create a panic device when none exist on the VMI.

**Special notes for your reviewer**:

All 20 Windows preference variants (XP through 2k25, including virtio variants) inherit from the Windows base and will get this setting. This is safe because the `hyperv` panic model is just an MSR — guests that don't support it simply never write to it.

**Release note**:
```release-note
Windows preferences now include a hyperv panic device, enabling Hyper-V crash notification (hv-crash) detection for Windows VMs.
```