### PR TITLE
fix: set Windows 11 and 10 preferredCPUTopology to cores

### DIFF
--- a/preferences/components/cpu-topology-cores/cpu-topology-cores.yaml
+++ b/preferences/components/cpu-topology-cores/cpu-topology-cores.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: cpu-topology-cores
+spec:
+  cpu:
+    preferredCPUTopology: cores

--- a/preferences/components/cpu-topology-cores/kustomization.yaml
+++ b/preferences/components/cpu-topology-cores/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: cpu-topology-cores.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: cpu-topology-cores.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/windows/10/kustomization.yaml
+++ b/preferences/windows/10/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/cpu-topology-cores
   - ../../components/secureboot
 
 nameSuffix: ".10"

--- a/preferences/windows/11/kustomization.yaml
+++ b/preferences/windows/11/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 components:
   - ./metadata
   - ./requirements
+  - ../../components/cpu-topology-cores
   - ../../components/efi-persisted
   - ../../components/tpm
   - ../../components/secureboot


### PR DESCRIPTION
**What this PR does / why we need it**:
These systems do not support more than 2 CPU sockets, so if a user creates a VM with more than 2 vCPUs, the other sockets will be ignored.

This PR changes preferred topology to use cores instead.


**Which issue(s) this PR fixes**:
Jira: https://redhat.atlassian.net/browse/CNV-87349


**Release note**:
```release-note
Windows 11 and Windows 10 preferences use "preferredCPUTopology" "cores".
```
