### PR TITLE
s390x: Add additional IBM Secure Execution preferences

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,36 @@
+# Using the yamllint configuration from Kubernetes
+# Source: https://github.com/kubernetes-sigs/kubebuilder/blob/f973a9e2be7280df8e3afd7db3923d380864f354/.yamllint
+
+# yamllint configuration for Kubebuilder
+# Aligns with Kubernetes YAML best practices:
+# - 2-space indentation, spaces only (no tabs)
+# - true/false over yes/no for booleans (truthy)
+# - Newline at end of file, no trailing spaces (POSIX)
+# - Unix newlines, consistent colons/hyphens
+# - No duplicate keys (key-duplicates)
+# - Document start (---) recommended for manifests; not enforced to allow existing testdata
+extends: default
+rules:
+  line-length:
+    max: 120
+    allow-non-breakable-words: true
+    # Generated CRDs and Prometheus manifests often have long lines
+    ignore: |
+      **/config/crd/bases/*.yaml
+      **/config/prometheus/*.yaml
+  indentation:
+    spaces: 2
+    # Kubernetes manifests often use list items at same indent as key (rules:\n- apiGroups:)
+    indent-sequences: whatever
+    # Uncommented replacement blocks in config/default/kustomization.yaml use 1-space for list items
+    ignore: |
+      **/config/default/kustomization.yaml
+  # Kubernetes: prefer true/false over yes/no; do not check keys (e.g. "on" in workflows)
+  truthy:
+    check-keys: false
+  # Allow single trailing blank line (common in editors)
+  empty-lines:
+    max-end: 1
+  # Optional: document-start (---) is K8s best practice but not enforced for testdata
+  document-start: disable
+  document-end: disable

--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ debian | Debian
 fedora | Fedora (amd64)
 fedora.arm64 | Fedora (arm64)
 fedora.s390x | Fedora (s390x)
+fedora.s390x.secex | Fedora (IBM Secure Execution)
 legacy | Legacy Guest
 linux | Linux Guest
 linux.efi | Linux EFI Guest
@@ -340,6 +341,7 @@ oraclelinux | Oracle Linux
 rhel.10 | Red Hat Enterprise Linux 10 (amd64)
 rhel.10.arm64 | Red Hat Enterprise Linux 10 (arm64)
 rhel.10.s390x | Red Hat Enterprise Linux 10 (s390x)
+rhel.10.s390x.secex | Red Hat Enterprise Linux 10 (IBM Secure Execution)
 rhel.7 | Red Hat Enterprise Linux 7
 rhel.7.desktop | Red Hat Enterprise Linux 7
 rhel.8 | Red Hat Enterprise Linux 8
@@ -351,6 +353,7 @@ rhel.9.desktop | Red Hat Enterprise Linux 9 Desktop (amd64)
 rhel.9.dpdk | Red Hat Enterprise Linux 9 DPDK (amd64)
 rhel.9.realtime | Red Hat Enterprise Linux 9 Realtime (amd64)
 rhel.9.s390x | Red Hat Enterprise Linux 9 (s390x)
+rhel.9.s390x.secex | Red Hat Enterprise Linux 9 (IBM Secure Execution)
 sles | SUSE Linux Enterprise Server
 ubuntu | Ubuntu
 windows.10 | Microsoft Windows 10

--- a/preferences/components/launch-security/kustomization.yaml
+++ b/preferences/components/launch-security/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./launch-security.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./launch-security.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/components/launch-security/launch-security.yaml
+++ b/preferences/components/launch-security/launch-security.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: launch-security
+spec:
+  preferredLaunchSecurity: {}

--- a/preferences/fedora/kustomization.yaml
+++ b/preferences/fedora/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./arm64
   - ./amd64
   - ./s390x
+  - ./s390x.secex

--- a/preferences/fedora/s390x.secex/kustomization.yaml
+++ b/preferences/fedora/s390x.secex/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../s390x
+
+components:
+  - ./metadata
+  - ../../components/launch-security
+
+nameSuffix: ".secex"

--- a/preferences/fedora/s390x.secex/metadata/kustomization.yaml
+++ b/preferences/fedora/s390x.secex/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/fedora/s390x.secex/metadata/metadata.yaml
+++ b/preferences/fedora/s390x.secex/metadata/metadata.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    tags: "hidden,kubevirt,fedora"
+    iconClass: "icon-fedora"
+    openshift.io/display-name: "Fedora (IBM Secure Execution)"
+  labels:
+    instancetype.kubevirt.io/arch: "s390x"

--- a/preferences/rhel/10/kustomization.yaml
+++ b/preferences/rhel/10/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./arm64
   - ./amd64
   - ./s390x
+  - ./s390x.secex

--- a/preferences/rhel/10/s390x.secex/kustomization.yaml
+++ b/preferences/rhel/10/s390x.secex/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../s390x
+
+components:
+  - ./metadata
+  - ../../../components/launch-security
+
+nameSuffix: ".secex"

--- a/preferences/rhel/10/s390x.secex/metadata/kustomization.yaml
+++ b/preferences/rhel/10/s390x.secex/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/rhel/10/s390x.secex/metadata/metadata.yaml
+++ b/preferences/rhel/10/s390x.secex/metadata/metadata.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 10 (IBM Secure Execution)"
+  labels:
+    instancetype.kubevirt.io/arch: "s390x"

--- a/preferences/rhel/9/kustomization.yaml
+++ b/preferences/rhel/9/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./arm64
   - ./amd64
   - ./s390x
+  - ./s390x.secex

--- a/preferences/rhel/9/s390x.secex/kustomization.yaml
+++ b/preferences/rhel/9/s390x.secex/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../s390x
+
+components:
+  - ./metadata
+  - ../../../components/launch-security
+
+nameSuffix: ".secex"

--- a/preferences/rhel/9/s390x.secex/metadata/kustomization.yaml
+++ b/preferences/rhel/9/s390x.secex/metadata/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachinePreference
+  - path: ./metadata.yaml
+    target:
+      kind: VirtualMachineClusterPreference

--- a/preferences/rhel/9/s390x.secex/metadata/metadata.yaml
+++ b/preferences/rhel/9/s390x.secex/metadata/metadata.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: instancetype.kubevirt.io/v1beta1
+kind: VirtualMachinePreference
+metadata:
+  name: metadata
+  annotations:
+    openshift.io/display-name: "Red Hat Enterprise Linux 9 (IBM Secure Execution)"
+
+  labels:
+    instancetype.kubevirt.io/arch: "s390x"


### PR DESCRIPTION
Allow customers to use IBM Secure Execution preferences for their images. This enables them to automatically enable it for their IBM Secure Execution images.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Part of [VEP 285](https://github.com/kubevirt/enhancements/issues/285)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added new preferences for Fedora and RHEL 9/10 with IBM Secure Execution enabled
```
